### PR TITLE
functions.inc.php

### DIFF
--- a/web/tools/users/acl_management/lib/functions.inc.php
+++ b/web/tools/users/acl_management/lib/functions.inc.php
@@ -26,8 +26,8 @@ function print_domains($type,$value)
 
 	global $config;
 
+	require("../../../../config/db.inc.php");
         require("../../../../config/tools/system/domains/local.inc.php");
-        require("../../../../config/db.inc.php");
         require("../../../../config/tools/system/domains/db.inc.php");
         require("db_connect.php");
 


### PR DESCRIPTION
PHP7.0 require type def before use, require("../../../../config/db.inc.php"); has to first else $config additions will be assumed to be stdClass::