### PR TITLE
[v1] Sip trunk regmode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 web/tools/system/smonitor/generated/
 tags
 *.swp
+*~
+*.bak

--- a/README
+++ b/README
@@ -58,6 +58,8 @@ OpenSIPS Control Panel currently features 3 main categories:
 
 	RTPProxy - provision and manage the RTPproxy instances used by OpenSIPS
 
+	SIP Trunk - provision and manage registrant instances via the SIP Trunk module
+
 	SIP Trace - viewer of the SIP data captured via the siptrace module
 
 	Statistics Monitor - viewer and charter for the statistics provided by OpenSIPS

--- a/config/modules.inc.php
+++ b/config/modules.inc.php
@@ -115,6 +115,10 @@ $config_modules 	= array (
 				"enabled"		=> true,
 				"name"			=> "Permissions"
 			),
+			"sip_trunk"			=> array (
+				"enabled"		=> true,
+				"name"			=> "SIP Trunk"
+			),
 			"siptrace"			=> array (
 				"enabled"		=> true,
 				"name"			=> "SIP Trace"

--- a/config/tools/system/sip_trunk/db.inc.php
+++ b/config/tools/system/sip_trunk/db.inc.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * $Id$
+ * Copyright (C) 2011 OpenSIPS Project
+ *
+ * This file is part of opensips-cp, a free Web Control Panel Application for
+ * OpenSIPS SIP server.
+ *
+ * opensips-cp is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * opensips-cp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+ //database host
+ //$config->db_host_sip_trunk = "loclhost";
+
+ //database port - leave empty for default
+ //$config->db_port_sip_trunk = "";
+
+ //database connection user
+ //$config->db_user_sip_trunk = "root";
+
+ //database connection password
+ //$config->db_pass_sip_trunk = "mysql";
+
+ //database name
+ //$config->db_name_sip_trunk = "opensips";
+
+ //if ($config->db_port_sip_trunk != "") $config->db_host_sip_trunk = $config->db_host_sip_trunk . ";port=" . $config->db_port_sip_trunk;
+
+?>

--- a/config/tools/system/sip_trunk/local.inc.php
+++ b/config/tools/system/sip_trunk/local.inc.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * $Id$
+ * Copyright (C) 2011 OpenSIPS Project
+ *
+ * This file is part of opensips-cp, a free Web Control Panel Application for
+ * OpenSIPS SIP server.
+ *
+ * opensips-cp is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * opensips-cp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+###############################################################################
+
+ //database tables
+ $config->table_registrant = "registrant";
+
+ // system to talk to via MI ?
+ $talk_to_this_assoc_id = 1 ;
+
+ // how to order result records
+ $config->results_per_page = 20;
+ $config->results_page_range = 5;
+
+?>

--- a/config/tools/system/sip_trunk/local.inc.php
+++ b/config/tools/system/sip_trunk/local.inc.php
@@ -33,4 +33,9 @@
  $config->results_per_page = 20;
  $config->results_page_range = 5;
 
+ // callback array for sip_trunk registration mode
+ $config->registration_mode=array(
+	 // type , description
+	 array("RFC6140", "Static Mode (RFC 6140)"),
+	 array("RFC3261", "Registration Mode (RFC 3261)") );
 ?>

--- a/web/common/forms.php
+++ b/web/common/forms.php
@@ -1,134 +1,134 @@
-<?php
-/*
-* Copyright (C) 2017 OpenSIPS Project
-*
-* This file is part of opensips-cp, a free Web Control Panel Application for
-* OpenSIPS SIP server.
-*
-* opensips-cp is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* opensips-cp is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, write to the Free Software
-* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-*/
-?>
+ <?php
+ /*
+  * Copyright (C) 2017 OpenSIPS Project
+  *
+  * This file is part of opensips-cp, a free Web Control Panel Application for
+  * OpenSIPS SIP server.
+  *
+  * opensips-cp is free software; you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation; either version 2 of the License, or
+  * (at your option) any later version.
+  *
+  * opensips-cp is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program; if not, write to the Free Software
+  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+  */
+ ?>
 
-<script language="JavaScript">
+ <script language="JavaScript">
 
-function get_elements() {
-	var arr=[];
+  function get_elements() {
+      var arr=[];
 
-	/* we need to support elements from both inputs and textareas now */
-	var inputs = document.getElementsByTagName('input');
-	var textareas = document.getElementsByTagName('textarea');
+      /* we need to support elements from both inputs and textareas now */
+      var inputs = document.getElementsByTagName('input');
+      var textareas = document.getElementsByTagName('textarea');
 
-	for (var i = 0; i < inputs.length; i++)
-		arr.push(inputs[i]);
-	for (var i = 0; i < textareas.length; i++)
-		arr.push(textareas[i]);
-	return arr;
-}
+      for (var i = 0; i < inputs.length; i++)
+	  arr.push(inputs[i]);
+      for (var i = 0; i < textareas.length; i++)
+	  arr.push(textareas[i]);
+      return arr;
+  }
 
-function form_init_status() {
-	elem = get_elements();
+  function form_init_status() {
+      elem = get_elements();
 
-	for(var i = 0; i < elem.length; i++) {
-		if (elem[i].oninput)
-			elem[i].oninput();
-	}
-}
+      for(var i = 0; i < elem.length; i++) {
+	  if (elem[i].oninput)
+	      elem[i].oninput();
+      }
+  }
 
-function form_full_check() {
-	elem = get_elements();
-	ret = true;
-	button = null;
+  function form_full_check() {
+      elem = get_elements();
+      ret = true;
+      button = null;
 
-	for(var i = 0; i < elem.length; i++) {
-		if (elem[i].getAttribute("opt")!=null && elem[i].getAttribute("opt")!="") {
-			if ( !(elem[i].getAttribute("opt")=="y" && elem[i].value=="") &&
-				!(elem[i].getAttribute("valid")=="ok") )
-				ret = false;
-		} else if (elem[i].type=="submit")
-			button = elem[i];
-	}
-	if (button!=null) {
-		if ( ret )
-			button.disabled = false;
-		else
-			button.disabled = true;
-	}
-}
+      for(var i = 0; i < elem.length; i++) {
+	  if (elem[i].getAttribute("opt")!=null && elem[i].getAttribute("opt")!="") {
+	      if ( !(elem[i].getAttribute("opt")=="y" && elem[i].value=="") &&
+		   !(elem[i].getAttribute("valid")=="ok") )
+		  ret = false;
+	  } else if (elem[i].type=="submit")
+	      button = elem[i];
+      }
+      if (button!=null) {
+	  if ( ret )
+	      button.disabled = false;
+	  else
+	      button.disabled = true;
+      }
+  }
 
-function validate_input(field, output, regex){
-	val = document.getElementById(field).value;
-	if (val=="") {
-		if (document.getElementById(field).getAttribute("opt")=="y")
-			document.getElementById(output).innerHTML = '';
-		else
-			document.getElementById(output).innerHTML = '<img src="../../../images/share/must-icon.png">';
-		document.getElementById(field).setAttribute("valid","ko");
-		ret =-1;
-	} else if (regex == null || val.match(new RegExp( regex,"g")) ) {
-		document.getElementById(output).innerHTML = '<img src="../../../images/share/ok_small.png">';
-		document.getElementById(field).setAttribute("valid","ok");
-		ret = 1;
-	} else {
-		document.getElementById(output).innerHTML = '<img src="../../../images/share/ko_small.png">';
-		document.getElementById(field).setAttribute("valid","ko");
-		ret = -1;
-	}
+  function validate_input(field, output, regex){
+      val = document.getElementById(field).value;
+      if (val=="") {
+	  if (document.getElementById(field).getAttribute("opt")=="y")
+	      document.getElementById(output).innerHTML = '';
+	  else
+	      document.getElementById(output).innerHTML = '<img src="../../../images/share/must-icon.png">';
+	  document.getElementById(field).setAttribute("valid","ko");
+	  ret =-1;
+      } else if (regex == null || val.match(new RegExp( regex,"g")) ) {
+	  document.getElementById(output).innerHTML = '<img src="../../../images/share/ok_small.png">';
+	  document.getElementById(field).setAttribute("valid","ok");
+	  ret = 1;
+      } else {
+	  document.getElementById(output).innerHTML = '<img src="../../../images/share/ko_small.png">';
+	  document.getElementById(field).setAttribute("valid","ko");
+	  ret = -1;
+      }
 
-	form_full_check();
-	return ret;
-}
+      form_full_check();
+      return ret;
+  }
 
-function validate_password(field, output, password){
-	pw1 = document.getElementById(field).value;
-	pw2 = document.getElementById(password).value;
-	if (pw2=="") {
-		if (document.getElementById(field).getAttribute("opt")=="y")
-			document.getElementById(output).innerHTML = '';
-		else
-			document.getElementById(output).innerHTML = '<img src="../../../images/share/must-icon.png">';
-		document.getElementById(field).setAttribute("valid","ko");
-		ret =-1;
-	} else if (pw1 == pw2) {
-		document.getElementById(output).innerHTML = '<img src="../../../images/share/ok_small.png">';
-		document.getElementById(field).setAttribute("valid","ok");
-		ret = 1;
-	} else {
-		document.getElementById(output).innerHTML = '<img src="../../../images/share/ko_small.png">';
-		document.getElementById(field).setAttribute("valid","ko");
-		ret = -1;
-	}
+  function validate_password(field, output, password){
+      pw1 = document.getElementById(field).value;
+      pw2 = document.getElementById(password).value;
+      if (pw2=="") {
+	  if (document.getElementById(field).getAttribute("opt")=="y")
+	      document.getElementById(output).innerHTML = '';
+	  else
+	      document.getElementById(output).innerHTML = '<img src="../../../images/share/must-icon.png">';
+	  document.getElementById(field).setAttribute("valid","ko");
+	  ret =-1;
+      } else if (pw1 == pw2) {
+	  document.getElementById(output).innerHTML = '<img src="../../../images/share/ok_small.png">';
+	  document.getElementById(field).setAttribute("valid","ok");
+	  ret = 1;
+      } else {
+	  document.getElementById(output).innerHTML = '<img src="../../../images/share/ko_small.png">';
+	  document.getElementById(field).setAttribute("valid","ko");
+	  ret = -1;
+      }
 
-	form_full_check();
-	return ret;
-}
-</script>
+      form_full_check();
+      return ret;
+  }
+ </script>
 
-<?php
-function form_generate_input_text($title,$tip,$id,$opt,$val,$mlen,$re) {
+ <?php
+ function form_generate_input_text($title,$tip,$id,$opt,$val,$mlen,$re) {
 
-	if ($val!=null)
-		$value=" value='".$val."' valid='ok'";
-	else 
-		$value = "";
+     if ($val!=null)
+	 $value=" value='".$val."' valid='ok'";
+     else
+	 $value = "";
 
-	if ($re==null)
-		$validate="";
-	else
-		$validate=" opt='".$opt."' oninput='validate_input(\"".$id."\", \"".$id."_ok\",\"".$re."\")'";
+     if ($re==null)
+	 $validate="";
+     else
+	 $validate=" opt='".$opt."' oninput='validate_input(\"".$id."\", \"".$id."_ok\",\"".$re."\")'";
 
-	print("
+     print("
 		<tr>
 			<td class='dataRecord'>
 				<b>".$title."</b>
@@ -145,24 +145,24 @@ function form_generate_input_text($title,$tip,$id,$opt,$val,$mlen,$re) {
 				</td></tr></table>
 			</td>
 		</tr>");
-}
+ }
 
-function form_generate_passwords($title,$val,$confirm_val,$minimum=6,$tip=null,$opt='y') {
+ function form_generate_passwords($title,$val,$confirm_val,$minimum=6,$tip=null,$opt='y') {
 
-	if ($val!=null)
-		$value=" value='".$val."' valid='ok'";
-	else
-		$value = "";
-	if ($confirm_val!=null)
-		$confirm_value=" value='".$val."' valid='ok'";
-	else 
-		$confirm_value = "";
+     if ($val!=null)
+	 $value=" value='".$val."' valid='ok'";
+     else
+	 $value = "";
+     if ($confirm_val!=null)
+	 $confirm_value=" value='".$val."' valid='ok'";
+     else
+	 $confirm_value = "";
 
-	if (!$tip) {
-		$tip = "Password";
-	}
+     if (!$tip) {
+	 $tip = "Password";
+     }
 
-	print("
+     print("
 		<tr>
 			<td class='dataRecord'>
 				<b>Password</b>
@@ -173,14 +173,14 @@ function form_generate_passwords($title,$val,$confirm_val,$minimum=6,$tip=null,$
 			<td class='dataRecord' width='250'>
 				<table style='width:100%'><tr><td>
 				<input type='password' name='".$title."'".$value." id='".$title."' class='dataInput' opt='".$opt.
-				"' oninput='validate_input(\"".$title."\", \"".$title."_ok\",\".{".$minimum."}.*\")'>
+	   "' oninput='validate_input(\"".$title."\", \"".$title."_ok\",\".{".$minimum."}.*\")'>
 				</td>
 				<td width='20'>
 				<div id='".$title."_ok'>".(($opt=='y' || $val!=null)?(""):("<img src='../../../images/share/must-icon.png'>"))."</div>
 				</td></tr></table>
 			</td>
 		</tr>");
-	print("
+     print("
 		<tr>
 			<td class='dataRecord'>
 				<b>Confirm Password</b>
@@ -191,18 +191,18 @@ function form_generate_passwords($title,$val,$confirm_val,$minimum=6,$tip=null,$
 			<td class='dataRecord' width='250'>
 				<table><tr><td>
 				<input type='password' name='confirm_".$title."'".$confirm_value." id='confirm_".$title."' class='dataInput' opt='".$opt.
-				"' oninput='validate_password(\"confirm_".$title."\", \"confirm_".$title."_ok\",\"".$title."\")'>
+	   "' oninput='validate_password(\"confirm_".$title."\", \"confirm_".$title."_ok\",\"".$title."\")'>
 				</td>
 				<td width='20'>
 				<div id='confirm_".$title."_ok'>".(($opt=='y' || $val!=null)?(""):("<img src='../../../images/share/must-icon.png'>"))."</div>
 				</td></tr></table>
 			</td>
 		</tr>");
-}
+ }
 
-function form_generate_select($title,$tip,$id,$mlen,$val,$vals,$texts=null) {
+ function form_generate_select($title,$tip,$id,$mlen,$val,$vals,$texts=null) {
 
-	print("
+     print("
 		<tr>
 			<td class='dataRecord'>
 				<b>".$title."</b>
@@ -213,11 +213,11 @@ function form_generate_select($title,$tip,$id,$mlen,$val,$vals,$texts=null) {
 			<td class='dataRecord' width='250'>
 				<table style='width:100%'><tr><td>
 				<select name='".$id."' id='".$id."' style='width: ".$mlen."px;' class='dataSelect'>");
-	for($i = 0; $i < count($vals); ++$i){
-		print("
+     for($i = 0; $i < count($vals); ++$i){
+	 print("
 					<option value='".$vals[$i]."'".(($val==$vals[$i])?" selected":"").">".($texts[$i]?$texts[$i]:$vals[$i])."</option>");
-	}
-	print("
+     }
+     print("
 				</select>
 				</td>
 				<td width='20'>
@@ -225,17 +225,65 @@ function form_generate_select($title,$tip,$id,$mlen,$val,$vals,$texts=null) {
 				</td></tr></table>
 			</td>
 		</tr>");
-}
+ }
 
 
-// Helpers to build complet validation regexp
+ // Helpers to build complet validation regexp
 
-# FreeSWITCH url (fs://[username]:password@host[:port])
-$re_fs_url ="(fs://[a-zA-Z0-9]*:[^@]+@[^:]+(:[0-9]+)?)";
+ # FreeSWITCH url (fs://[username]:password@host[:port])
+ $re_fs_url ="(fs://[a-zA-Z0-9]*:[^@]+@[^:]+(:[0-9]+)?)";
 
-# SIP URI
-$re_sip_uri = "sip(s)?:([^@]+@)?[^:]+(:[0-9]+)?";
+ # RegEx matching an IPv4 addr
+ $re_ipv4 = "(" .
+	    "([0-9]|[1-9][0-9]|1[0-9]{2}|" .
+	    "2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|" .
+	    "1[0-9]{2}|2[0-4][0-9]|25[0-5]" .
+	    ")";
 
-$re_ip = "([0-9]{1,3}\\\.[0-9]{1,3}\\\.[0-9]{1,3}\\\.[0-9]{1,3})";
+ # RegEx matching an IPv6 addr
+ $re_ipv6 = "(" .
+	    "([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|" .
+	    "([0-9a-fA-F]{1,4}:){1,7}:|" .
+	    "([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|" .
+	    "([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|" .
+	    "([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|" .
+	    "([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|" .
+	    "([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|" .
+	    "[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|" .
+	    ":((:[0-9a-fA-F]{1,4}){1,7}|" .
+	    ":)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|" .
+	    "::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|" .
+	    "(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|" .
+	    "(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|" .
+	    "([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|" .
+	    "(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|" .
+	    "(2[0-4]|1{0,1}[0-9]){0,1}[0-9])" .
+	    ")";
 
-?>
+ # RegEx matching a FQDN
+ $re_fqdn = "((?=.{4,253})" .
+	    "(((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)" .
+	    "+[a-zA-Z]{2,63}))";
+
+ # RegEx matching a PSTN Number
+ $re_pstn = "([0-9+]+)";
+
+ # RegEx matching URI's: ipv4addr or ipv6addr or fqdn
+ $re_uris = "(" . $re_ipv4 .
+	    "|" . $re_ipv6 .
+	    "|" . $re_fqdn .
+	    ")?";
+
+ # RegEx IP's: ipv4addr or ipv6addr
+ $re_ips = "(" . $re_ipv4 .
+	   "|" . $re_ipv6 .
+	   ")?";
+
+ # RegEx SIP URI's: sip or sips : ipv4addr or ipv6addr or fqdn
+ $re_sip_uris = "sip(s)?:" .
+		"(" . $re_ipv4 .
+		"|" . $re_ipv6 .
+		"|" . $re_fqdn .
+		")?";
+
+ ?>

--- a/web/common/forms.php
+++ b/web/common/forms.php
@@ -37,6 +37,108 @@
       return arr;
   }
 
+  function get_element_selected(id, referid) {
+      var elementId = document.getElementById(id);
+      var mode = elementId.options[elementId.selectedIndex].value;
+      var mode_txt = elementId.options[elementId.selectedIndex].text;
+      //alert("Selected Item " + mode + ", Value " + mode_txt);
+
+      //var referid_tooltip = document.getElementById(referid) + "_tooltip";
+      var referid_tooltip = referid + "_tooltip";
+
+      // RegEx matching a FQDN
+      var re_fqdn;
+      re_fqdn = "((?=.{4,253})";
+      re_fqdn = re_fqdn + "(((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)";
+      re_fqdn = re_fqdn + "+[a-zA-Z]{2,63}))";
+      //alert(re_fqdn);
+
+      var re_ipv4;
+      re_ipv4 = "(";
+      re_ipv4 = re_ipv4 + "([0-9]|[1-9][0-9]|1[0-9]{2}|";
+      re_ipv4 = re_ipv4 + "2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|";
+      re_ipv4 = re_ipv4 + "1[0-9]{2}|2[0-4][0-9]|25[0-5]";
+      re_ipv4 = re_ipv4 + ")";
+      //alert(re_ipv4);
+
+      // RegEx matching an IPv6 addr
+      re_ipv6 = "(";
+      re_ipv6 = re_ipv6 + "([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|";
+      re_ipv6 = re_ipv6 + "([0-9a-fA-F]{1,4}:){1,7}:|";
+      re_ipv6 = re_ipv6 + "([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|";
+      re_ipv6 = re_ipv6 + "([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|";
+      re_ipv6 = re_ipv6 + "([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|";
+      re_ipv6 = re_ipv6 + "([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|";
+      re_ipv6 = re_ipv6 + "([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|";
+      re_ipv6 = re_ipv6 + "[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|";
+      re_ipv6 = re_ipv6 + ":((:[0-9a-fA-F]{1,4}){1,7}|";
+      re_ipv6 = re_ipv6 + ":)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|";
+      re_ipv6 = re_ipv6 + "::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|";
+      re_ipv6 = re_ipv6 + "(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|";
+      re_ipv6 = re_ipv6 + "(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|";
+      re_ipv6 = re_ipv6 + "([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|";
+      re_ipv6 = re_ipv6 + "(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|";
+      re_ipv6 = re_ipv6 + "(2[0-4]|1{0,1}[0-9]){0,1}[0-9])";
+      re_ipv6 = re_ipv6 + ")";
+      //alert(re_ipv6);
+
+      // RegEx matching a PSTN Number
+      re_pstn = "([0-9+]+)";
+      //alert(re_pstn);
+
+      // RegEx matching URI's: ipv4addr or ipv6addr or fqdn
+      re_uris = "(" + re_ipv4;
+      re_uris = re_uris + "|" + re_ipv6;
+      re_uris = re_uris + "|" + re_fqdn;
+      re_uris = re_uris + ")?";
+      //alert(re_uris);
+
+      // RegEx IP's: ipv4addr or ipv6addr
+      re_ips = "(" + re_ipv4;
+      re_ips = re_ips + "|" + re_ipv6;
+      re_ips = re_ips + ")?";
+      //alert(re_ips);
+
+      // RegEx SIP URI's: sip or sips : ipv4addr or ipv6addr or fqdn
+      re_sip_uris = "sip(s)?:";
+      re_sip_uris = re_sip_uris + "(" + re_ipv4;
+      re_sip_uris = re_sip_uris + "|" + re_ipv6;
+      re_sip_uris = re_sip_uris + "|" + re_fqdn;
+      re_sip_uris = re_sip_uris + ")?";
+      //alert(re_sip_uris);
+
+      // RegEx Static-Mode
+      re_static_mode = "^sip(s)?:";
+      re_static_mode = re_static_mode + re_uris;
+      re_static_mode = re_static_mode + "(:(5060|5061)?)?;bnc$";
+      //alert(re_static_mode);
+
+      // RegEx Registration-Mode
+      re_reg_mode = "^sip(s)?:";
+      re_reg_mode = re_reg_mode + re_pstn + "@";
+      re_reg_mode = re_reg_mode + re_uris + "(:(5060|5061)?)?$";
+      //alert(re_reg_mode);
+
+      ret = -1;
+      if (mode == "RFC6140") {
+	  var tooltip_RFC6140 = "Contact Header associated to the given SIP registrant (eg: sip:'IP-Addr':'port';bnc)";
+	  //alert(registrar_tooltip);
+	  //document.getElementById(referid).value = "RFC6140";
+	  document.getElementById(referid_tooltip).innerText = tooltip_RFC6140;
+	  document.getElementById(referid).setAttribute("re", re_static_mode);
+	  ret = 1;
+
+      } else if (mode == "RFC3261") {
+	  var tooltip_RFC3261 = "Contact Header associated to the given SIP registrant (eg: sip:'PSTN-Nr'@sip-trunk.telekom.de:5060)"
+	  //document.getElementById(referid).value = "RFC3261";
+	  document.getElementById(referid_tooltip).innerText = tooltip_RFC3261;
+	  document.getElementById(referid).setAttribute("re", re_reg_mode);
+	  ret = 1;
+      }
+
+      return ret;
+  }
+
   function form_init_status() {
       elem = get_elements();
 
@@ -113,38 +215,87 @@
       form_full_check();
       return ret;
   }
+
  </script>
 
  <?php
+ // server side
  function form_generate_input_text($title,$tip,$id,$opt,$val,$mlen,$re) {
 
-     if ($val!=null)
-	 $value=" value='".$val."' valid='ok'";
+     if ($val != null)
+	 $value = " value='" . $val . "' valid='ok'";
      else
 	 $value = "";
 
-     if ($re==null)
-	 $validate="";
+     if ($re == null)
+	 $validate = "";
      else
-	 $validate=" opt='".$opt."' oninput='validate_input(\"".$id."\", \"".$id."_ok\",\"".$re."\")'";
+	 $validate= " opt='" . $opt . "' oninput='validate_input(\"" . $id . "\", \"" . $id . "_ok\", \"" . $re . "\")'";
 
      print("
-		<tr>
-			<td class='dataRecord'>
-				<b>".$title."</b>
-				<div class='tooltip'><sup>?</sup>
-				<span class='tooltiptext'>".$tip."</span>
-				</div>
-			</td>
-			<td class='dataRecord' width='250'>
-				<table style='width:100%'><tr><td>
-				<input type='text' name='".$id."'".$value." id='".$id."' maxlength='".$mlen."' class='dataInput'".$validate.">
-				</td>
-				<td width='20'>
-				<div id='".$id."_ok'>".(($opt=='y' || $val!=null)?(""):("<img src='../../../images/share/must-icon.png'>"))."</div>
-				</td></tr></table>
-			</td>
-		</tr>");
+<tr>
+    <td class='dataRecord'>
+	<b>" . $title . "</b>
+	<div class='tooltip'><sup>?</sup>
+	    <span class='tooltiptext' id='" . $id . "_tooltip'>" . $tip . "</span>
+	</div>
+    </td>
+    <td class='dataRecord' width='380'>
+	<table style='width:100%'>
+	    <tr>
+		<td>
+		    <input type='text' name='" . $id . "'" . $value . " id='" . $id . "'
+			maxlength='" . $mlen . "' class='dataInput'" . $validate . ">
+		</td>
+		<td width='20'>
+		    <div id='" . $id . "_ok'>" .
+		       ( ($opt == 'y' || $val != null) ? ("") : ("<img src='../../../images/share/must-icon.png'>") ) . "
+		    </div>
+		</td>
+	    </tr>
+	</table>
+    </td>
+</tr>
+    ");
+ }
+
+ function form_generate_input_registrar($title,$registrar_tooltip,$id,$opt,$val,$mlen,$re) {
+
+     if ($val != null)
+	 $value = " value='" . $val . "' valid='ok' re=''";
+     else
+	 $value = "";
+
+     if ($re == null)
+	 $validate = "";
+     else
+	 $validate = " opt='".$opt."' oninput='validate_input(\"".$id."\", \"".$id."_ok\",\"".$re."\")'";
+
+     print("
+<tr>
+    <td class='dataRecord'>
+	<b>" . $title . "</b>
+	<div class='tooltip'><sup>?</sup>
+	    <span class='tooltiptext' id='" . $id . "_tooltip'>" . $tip . "</span>
+	</div>
+    </td>
+    <td class='dataRecord' width='380'>
+	<table style='width:100%'>
+	    <tr>
+		<td>
+		    <input type='text' name='" . $id . "'" . $value . " id='" . $id . "' maxlength='" . $mlen . "'
+			class='dataInput'" . $validate . ">
+		</td>
+		<td width='20'>
+		    <div id='" . $id . "_ok'>" .
+			( ($opt == 'y' || $val != null ) ? ("") : ("<img src='../../../images/share/must-icon.png'>") ) ."
+		    </div>
+		</td>
+	    </tr>
+	</table>
+    </td>
+</tr>"
+     );
  }
 
  function form_generate_passwords($title,$val,$confirm_val,$minimum=6,$tip=null,$opt='y') {
@@ -163,70 +314,110 @@
      }
 
      print("
-		<tr>
-			<td class='dataRecord'>
-				<b>Password</b>
-				<div class='tooltip'><sup>?</sup>
-				<span class='tooltiptext'>Enter ".$tip."<br> (minimum ".$minimum. " characters)</span>
-				</div>
-			</td>
-			<td class='dataRecord' width='250'>
-				<table style='width:100%'><tr><td>
-				<input type='password' name='".$title."'".$value." id='".$title."' class='dataInput' opt='".$opt.
+<tr>
+    <td class='dataRecord'>
+	<b>Password</b>
+	<div class='tooltip'><sup>?</sup>
+	    <span class='tooltiptext'>Enter ".$tip."<br> (minimum ".$minimum. " characters)</span>
+	</div>
+    </td>
+    <td class='dataRecord' width='250'>
+	<table style='width:100%'><tr><td>
+	    <input type='password' name='".$title."'".$value." id='".$title."' class='dataInput' opt='".$opt.
 	   "' oninput='validate_input(\"".$title."\", \"".$title."_ok\",\".{".$minimum."}.*\")'>
-				</td>
-				<td width='20'>
-				<div id='".$title."_ok'>".(($opt=='y' || $val!=null)?(""):("<img src='../../../images/share/must-icon.png'>"))."</div>
-				</td></tr></table>
-			</td>
-		</tr>");
+	</td>
+	<td width='20'>
+	    <div id='".$title."_ok'>".(($opt=='y' || $val!=null)?(""):("<img src='../../../images/share/must-icon.png'>"))."</div>
+	</td></tr></table>
+    </td>
+</tr>
+     ");
+
      print("
-		<tr>
-			<td class='dataRecord'>
-				<b>Confirm Password</b>
-				<div class='tooltip'><sup>?</sup>
-				<span class='tooltiptext'>Confirm ".$tip."<br></span>
-				</div>
-			</td>
-			<td class='dataRecord' width='250'>
-				<table><tr><td>
-				<input type='password' name='confirm_".$title."'".$confirm_value." id='confirm_".$title."' class='dataInput' opt='".$opt.
+<tr>
+    <td class='dataRecord'>
+	<b>Confirm Password</b>
+	<div class='tooltip'><sup>?</sup>
+	    <span class='tooltiptext'>Confirm ".$tip."<br></span>
+	</div>
+    </td>
+    <td class='dataRecord' width='250'>
+	<table><tr><td>
+	    <input type='password' name='confirm_".$title."'".$confirm_value." id='confirm_".$title."' class='dataInput' opt='".$opt.
 	   "' oninput='validate_password(\"confirm_".$title."\", \"confirm_".$title."_ok\",\"".$title."\")'>
-				</td>
-				<td width='20'>
-				<div id='confirm_".$title."_ok'>".(($opt=='y' || $val!=null)?(""):("<img src='../../../images/share/must-icon.png'>"))."</div>
-				</td></tr></table>
-			</td>
-		</tr>");
+	</td>
+	<td width='20'>
+	    <div id='confirm_".$title."_ok'>".(($opt=='y' || $val!=null)?(""):("<img src='../../../images/share/must-icon.png'>"))."</div>
+	</td></tr></table>
+    </td>
+</tr>
+    ");
  }
 
- function form_generate_select($title,$tip,$id,$mlen,$val,$vals,$texts=null) {
+ function form_generate_select($title,$tip,$id,$mlen,$val,$vals,$texts=null,$referid) {
+
+     // content of $ds_form['attribute'] is passed as $val
+     // if not 'preset' -> mark first arry element as 'selected'
+     $value = array();
+
+     if ( $val == null )
+	 $val = $vals[0];
+
+     // debug:
+     #print(" <tr><td width='400'> val: '" . $val . "' </td> </tr>" );
 
      print("
-		<tr>
-			<td class='dataRecord'>
-				<b>".$title."</b>
-				<div class='tooltip'><sup>?</sup>
-				<span class='tooltiptext'>".$tip."</span>
-				</div>
-			</td>
-			<td class='dataRecord' width='250'>
-				<table style='width:100%'><tr><td>
-				<select name='".$id."' id='".$id."' style='width: ".$mlen."px;' class='dataSelect'>");
-     for($i = 0; $i < count($vals); ++$i){
-	 print("
-					<option value='".$vals[$i]."'".(($val==$vals[$i])?" selected":"").">".($texts[$i]?$texts[$i]:$vals[$i])."</option>");
+<tr>
+    <td class='dataRecord'>
+	<b>".$title."</b>
+	<div class='tooltip'><sup>?</sup>
+	    <span class='tooltiptext'>".$tip."</span>
+	</div>
+    </td>
+    <td class='dataRecord' width='250'>
+	<table style='width:100%'>
+	    <tr>
+		<td>
+		    <select name='" . $id ."' id='" . $id . "' style='width: " . $mlen . "px;' class='dataSelect'
+			    onChange='get_element_selected(\"".$id."\", \"".$referid."\")'>
+			    //onfocus='get_element_selected(\"".$id."\", \"".$referid."\")'>
+			"
+     );
+
+     for( $i = 0; $i < count($vals); ++$i ) {
+	 print("<option value='" . $vals[$i] . "'" .
+	       ( ( $val == $vals[$i] ) ? " selected" : "" ) .
+	       ">" .
+	       ( $texts[$i] ? $texts[$i] : $vals[$i] ) .
+	       "</option>"
+	 );
+
+	 // debug:
+	 //$value[$i] = ( $val == $vals[$i] ) ? ' selected' : ' not selected';
      }
      print("
-				</select>
-				</td>
-				<td width='20'>
-				<div id='".$id."_ok'></div>
-				</td></tr></table>
-			</td>
-		</tr>");
- }
+		    </select>
+		</td>
+		<td width='20'>
+		    <div id='".$id."_ok'></div>
+		</td>
+	    </tr>
+	</table>
+    </td>
+</tr>
+    ");
 
+     // debug:
+     //for ( $i = 0; $i < count($vals); ++$i ) {
+     // print(" <tr><td width='400'> key[" . $i . "]: '" . $vals[$i] . "value[" . $i . "]: '" . $value[$i] . "' </td> </tr>" );
+     //}
+
+     //print(" <tr><td width='400'> Selected-Id:" . $_POST['registrar_mode'] . "' </td> </tr>" );
+     //$registrar_mode = $_POST['registrar_mode'];
+     #$selected = $_POST['registrar_mode'];
+     //print(" <tr><td width='400'> Selected-Id:" . $registrar_mode . "' </td> </tr>" );
+     //return $registrar_mode;
+ }
 
  // Helpers to build complet validation regexp
 

--- a/web/tools/system/sip_trunk/apply_changes.php
+++ b/web/tools/system/sip_trunk/apply_changes.php
@@ -1,0 +1,50 @@
+<?php
+/*
+* Copyright (C) 2019 OpenSIPS Project
+*
+* This file is part of opensips-cp, a free Web Control Panel Application for
+* OpenSIPS SIP server.
+*
+* opensips-cp is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* opensips-cp is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*/
+
+require_once("../../../../config/session.inc.php");
+require("../../../../config/tools/system/sip_trunk/local.inc.php");
+require("../../../common/mi_comm.php");
+require("../../../common/cfg_comm.php");
+
+$command="sip_trunk_reload";
+
+?>
+<fieldset><legend>Sending MI command: <?=$command?></legend>
+<br>
+<?php
+
+$mi_connectors=get_proxys_by_assoc_id($talk_to_this_assoc_id);
+
+for ( $i=0; $i<count($mi_connectors); $i++ ) {
+	echo "Sending to <b>".$mi_connectors[$i]."</b> : ";
+
+	$message=mi_command($command, $mi_connectors[$i], $errors, $status);
+
+	if ( !$errors ) {
+		echo "<font color='green'><b>Success</b></font>";
+	}
+	echo "<br>";
+}
+
+?>
+
+</fieldset>

--- a/web/tools/system/sip_trunk/index.php
+++ b/web/tools/system/sip_trunk/index.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * Copyright (C) 2011 OpenSIPS Project
+ *
+ * This file is part of opensips-cp, a free Web Control Panel Application for
+ * OpenSIPS SIP server.
+ *
+ * opensips-cp is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * opensips-cp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+ require("../../../common/cfg_comm.php");
+ session_start();
+ get_priv("sip_trunk");
+ header("Location: sip_trunk.php");
+
+?>

--- a/web/tools/system/sip_trunk/lib/db_connect.php
+++ b/web/tools/system/sip_trunk/lib/db_connect.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Copyright (C) 2011 OpenSIPS Project
+ *
+ * This file is part of opensips-cp, a free Web Control Panel Application for
+ * OpenSIPS SIP server.
+ *
+ * opensips-cp is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * opensips-cp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+
+require_once("../../../../config/tools/system/sip_trunk/db.inc.php");
+require_once("../../../../config/db.inc.php");
+
+        global $config;
+        if (isset($config->db_host_sip_trunk) && isset($config->db_user_sip_trunk) && isset($config->db_name_sip_trunk) ) {
+                $config->db_host = $config->db_host_sip_trunk;
+                $config->db_port = $config->db_port_sip_trunk;
+                $config->db_user = $config->db_user_sip_trunk;
+                $config->db_pass = $config->db_pass_sip_trunk;
+                $config->db_name = $config->db_name_sip_trunk;
+        }
+    $dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
+    try {
+        $link = new PDO($dsn, $config->db_user, $config->db_pass);
+    } catch (PDOException $e) {
+        error_log(print_r("Failed to connect to: ".$dsn, true));
+        print "Error!: " . $e->getMessage() . "<br/>";
+        die();
+    }
+?>

--- a/web/tools/system/sip_trunk/lib/functions.inc.php
+++ b/web/tools/system/sip_trunk/lib/functions.inc.php
@@ -1,0 +1,44 @@
+<?php
+/*
+* Copyright (C) 2011 OpenSIPS Project
+*
+* This file is part of opensips-cp, a free Web Control Panel Application for
+* OpenSIPS SIP server.
+*
+* opensips-cp is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* opensips-cp is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*/
+
+function get_sip_trunk($module, $has_any)
+{
+
+    global $config;
+
+    require("../../../../config/tools/system/sip_trunk/local.inc.php");
+    require("../../../../config/db.inc.php");
+    require("../../../../config/tools/system/sip_trunk/db.inc.php");
+    require("db_connect.php");
+
+    $table_sip_trunk=$config->table_sip_trunk;
+
+    $sql="select registrant from $table_sip_trunk";
+    $result = $link->query($sql)->fetchAll(PDO::FETCH_COLUMN);
+
+    if ($has_any)
+        array_unshift($result, "ANY");
+
+    return $result;
+}
+
+?>

--- a/web/tools/system/sip_trunk/lib/sip_trunk.main.js
+++ b/web/tools/system/sip_trunk/lib/sip_trunk.main.js
@@ -1,0 +1,93 @@
+<script language="JavaScript">
+
+function confirmDelete(id)
+{
+	var agree=confirm("Are you sure you want to delete SIP Trunk registrant '"+id+"' ?");
+	if (agree)
+		return true;
+	else
+		return false;
+}
+
+function handleHttpResponse(http) {
+
+	if (http.readyState == 4) {
+		if(http.status==200) {
+			ok = true;
+			//return results;
+		}
+	}
+}
+
+function getHTTPObject() {
+
+	var request = false;
+	try {
+		request = new XMLHttpRequest();
+	} catch (trymicrosoft) {
+		try {
+			request = new ActiveXObject("Msxml2.XMLHTTP");
+		} catch (othermicrosoft) {
+			try {
+				request = new ActiveXObject("Microsoft.XMLHTTP");
+			} catch (failed) {
+				request = false;
+			}
+		}
+ 	}
+
+	if (!request)
+		alert("Error initializing XMLHttpRequest!");
+
+	return request;
+}
+
+
+function centerMe(element) {
+//pass element name to be centered on screen
+	var pWidth = window.innerWidth;
+	var pTop =  window.scrollTop;
+	var eWidth = document.getElementById(element).style.width
+	var height = document.getElementById(element).style.height
+	document.getElementById(element).style.top = '250px';
+	//$(element).css('top',pTop+100+'px')
+	document.getElementById(element).style.left = parseInt((pWidth / 2) - 205) + 'px';
+}
+
+
+
+function closeDialog() {
+	document.getElementById('overlay').style.display = 'none';
+	document.getElementById('dialog').style.display = 'none';
+	document.getElementById('dialog').innerHTML = '';
+}
+
+function apply_changes(){
+	url = "apply_changes.php";
+
+	var http = getHTTPObject();
+
+	http.open("GET", url, false);
+	http.onreadystatechange = handleHttpResponse(http);
+	http.send(null);
+	result = http.responseText;
+
+	var body = document.body,
+	html = document.documentElement;
+
+	var height = Math.max( body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight );
+
+
+	document.getElementById('overlay').style.height = height;
+	document.getElementById('overlay').style.display = 'block';
+	document.getElementById('dialog').innerHTML = result;
+	centerMe('dialog')
+	document.getElementById('overlay').onclick = function () {closeDialog();};
+	document.getElementById('dialog').style.display = 'block';
+	return true;
+
+	document.getElementById("content").innerHTML = "whatever";
+
+	return true;
+}
+</script>

--- a/web/tools/system/sip_trunk/sip_trunk.php
+++ b/web/tools/system/sip_trunk/sip_trunk.php
@@ -1,0 +1,389 @@
+<?php
+/*
+* Copyright (C) 2019 OpenSIPS Project
+*
+* This file is part of opensips-cp, a free Web Control Panel Application for
+* OpenSIPS SIP server.
+*
+* opensips-cp is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* opensips-cp is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*/
+
+require("template/header.php");
+require("lib/" . $page_id . ".main.js");
+require ("../../../common/mi_comm.php");
+require("../../../common/cfg_comm.php");
+include("lib/db_connect.php");
+
+$table = $config->table_registrant;
+$current_page = "current_page_registrant";
+
+if ( isset($_POST['action']) )
+	$action=$_POST['action'];
+else if ( isset($_GET['action']) )
+	$action=$_GET['action'];
+else
+	$action = "";
+
+if ( isset($_GET['page']) )
+	$_SESSION[$current_page]=$_GET['page'];
+else if ( !isset($_SESSION[$current_page]) )
+	$_SESSION[$current_page]=1;
+
+#################
+# start add new #
+#################
+
+if ( $action == "add" )
+{
+	extract($_POST);
+	if( !$_SESSION['read_only'] )
+	{
+		require("template/".$page_id.".add.php");
+		require("template/footer.php");
+		exit();
+	} else {
+		$errors = "User with Read-Only Rights";
+	}
+}
+#################
+# end add new   #
+#################
+
+####################
+# start add_verify #
+####################
+if ( $action == "add_verify" ) {
+	$info = "";
+	$errors = "";
+
+	if( !$_SESSION['read_only'] ) {
+		$registrar = $_POST['registrar'];
+		$proxy = $_POST['proxy'];
+		$registrar_mode = $_POST['registrar_mode'];
+		$aor = $_POST['aor'];
+		$third_party_registrant = $_POST['third_party_registrant'];
+		$username = $_POST['username'];
+		$password  = $_POST['password'];
+		$binding_uri = $_POST['binding_uri'];
+		$binding_params = $_POST['binding_params'];
+		$expiry = $_POST['expiry'];
+		$forced_socket = $_POST['forced_socket'];
+		$cluster_shtag = $_POST['cluster_shtag'];
+
+		if( $registrar == "" || $proxy == "" || $aor == "" || $username == "" || $password == "") {
+			print "Invalid data!!";
+		}
+
+		if ( $errors == "" ) {
+			$sql = "SELECT count(*) FROM ".$table." WHERE registrar=? and proxy=? AND aor=?";
+			$stm = $link->prepare($sql);
+			if ($stm === FALSE)
+				die('Failed to issue query, error message : ' .
+					print_r($link->errorInfo(), true));
+			$stm->execute(array($registrar, $proxy, $aor));
+			if ( $stm->fetchColumn(0) > 0 ) {
+				$errors = "Duplicate Registrar";
+			} else {
+				$sql_command = "INSERT INTO " . $table .
+				"(registrar, proxy, registrar_mode, aor, third_party_registrant, username, password, " .
+				"binding_uri, binding_params, expiry, forced_socket, cluster_shtag) " .
+							 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+				$stm = $link->prepare($sql_command);
+				if ( $stm->execute( array($registrar, $proxy, $registrar_mode, $aor, $third_party_registrant, $username, $password, $binding_uri, $binding_params, $expiry, $forced_socket, $cluster_shtag) ) === false ) {
+					$errors = "Inserting record into DB failed: ".print_r($stm->errorInfo(), true);
+				} else {
+					$info = "The new record was added";
+				}
+			}
+		}
+	} else {
+		$errors = "User with Read-Only Rights";
+	}
+}
+##################
+# end add_verify #
+##################
+
+#####################################
+# start add_verify cloned registrar #
+#####################################
+if ( $action == "add_verify_registrar" )
+{
+	$info = "";
+	$errors = "";
+
+	if(!$_SESSION['read_only']){
+
+		$src_registrar = $_POST['src'];
+		$dst_registrar = $_POST['dst'];
+
+		if ($src_registrar == "" || $dst_registrar == ""){
+			$errors = "Empty source or destination registrar";
+		}else if($src_registrar == $dst_registrar){
+			$errors = "Source the same as destination";
+		}
+
+		if ($errors == "") {
+			$sql = "SELECT * FROM ".$table." WHERE registrar=?";
+			$stm = $link->prepare($sql);
+			if ($stm === FALSE)
+				die('Failed to issue query, error message : ' . print_r($link->errorInfo(), true));
+			$stm->execute(array($src_registrar));
+			$resultset = $stm->fetchAll(PDO::FETCH_ASSOC);
+
+			if (count($resultset)==0) {
+				$errors = "No rules to duplicate";
+			} else {
+				for ($i=0; $i<count($resultset); $i++)
+				{
+					$sql_command = "INSERT INTO " . $table .
+								 "(registrar, proxy, registrar_mode, aor, third_party_registrant, username, password, " .
+								 "binding_uri, binding_params, expiry, forced_socket, cluster_shtag) " .
+								 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+					$stm = $link->prepare($sql);
+					if ($stm === false) {
+						die('Failed to issue query [' .$sql . '], error message : ' . print_r($link->errorInfo(), true));
+					}
+					if ($stm->execute( array($dst_registrar,$resultset[$i]['proxy'],
+											 $resultset[$i]['registrar_mode'],['aor'],
+											 $resultset[$i]['third_party_registrant'],$resultset[$i]['username'],
+											 $resultset[$i]['password'],$resultset[$i]['binding_uri'],
+											 $resultset[$i]['binding_params'], $resultset[$i]['expiry'],
+											 $resultset[$i]['forced_socket'],
+											 $resultset[$i]['cluster_shtag']) ) == false )
+						$errors .= "Inserting record into DB failed: " . print_r($stm->errorInfo(), true);
+				}
+				$info = "The dialplan was cloned";
+			}
+		}
+	} else {
+		$errors= "User with Read-Only Rights";
+	}
+}
+###################################
+# end add_verify cloned registrar #
+###################################
+
+################
+# change state #
+################
+if ( $action == "change_state" ) {
+
+	$state = $_GET['state'];
+	$sock = $_GET['sock'];
+
+	$mi_connectors=get_proxys_by_assoc_id($talk_to_this_assoc_id);
+	for ( $i=0; $i<count($mi_connectors); $i++ ) {
+		if ($state == "0") {
+			mi_command("sip_trunk_enable $sock 0" , $mi_connectors[$i], $errors , $status);
+		} else {
+			mi_command("sip_trunk_enable $sock 1" , $mi_connectors[$i], $errors , $status);
+		}
+	}
+
+}
+####################
+# end change state #
+####################
+
+###############
+# start clone #
+###############
+if ( $action == "clone" )
+{
+	if( !$_SESSION['read_only'] ) {
+		extract($_POST);
+		require("template/".$page_id.".clone.php");
+		//require("template/".$page_id.".add.php");
+		require("template/footer.php");
+		exit();
+	} else {
+		$errors= "User with Read-Only Rights";
+	}
+}
+###############
+# end clone   #
+###############
+
+################
+# start delete #
+################
+if ( $action == "delete" )
+{
+	if( !$_SESSION['read_only'] ) {
+		$id = $_GET['id'];
+		$sql = "DELETE FROM " . $table . " WHERE id = ?";
+		$stm = $link->prepare($sql);
+		if ( $stm->execute( array($id) ) === false )
+			die('Failed to issue query, error message : ' . print_r($stm->errorInfo(), true));
+	} else {
+		$errors = "User with Read-Only Rights";
+	}
+}
+##############
+# end delete #
+##############
+
+##############
+# start edit #
+##############
+if ( $action == "edit" )
+{
+
+	if ( !$_SESSION['read_only'] ){
+		extract($_POST);
+
+		require("template/" . $page_id . ".edit.php");
+		require("template/footer.php");
+		exit();
+	} else {
+		$errors = "User with Read-Only Rights";
+	}
+}
+#############
+# end edit  #
+#############
+
+#################
+# start modify	#
+#################
+if ( $action == "modify" )
+{
+	$info = "";
+	$errors = "";
+
+	if( !$_SESSION['read_only'] ) {
+		$id = $_GET['id'];
+		$registrar=$_POST['registrar'];
+		$proxy = $_POST['proxy'];
+		$registrar_mode=$_POST['registrar_mode'];
+		$aor = $_POST['aor'];
+		$third_party_registrant = $_POST['third_party_registrant'];
+		$username = $_POST['username'];
+		$password  = $_POST['password'];
+		$binding_uri = $_POST['binding_uri'];
+		$binding_params = $_POST['binding_params'];
+		$expiry = $_POST['expiry'];
+		$forced_socket = $_POST['forced_socket'];
+		$cluster_shtag = $_POST['cluster_shtag'];
+
+		if( $registrar == "" || $proxy == "" || $aor == "" || $username == "" || $password == "") {
+			print "Invalid data!!";
+		}
+
+		if ( $registrar == "" ) {
+			$errors = "Invalid data, the entry was not modified in the database";
+		}
+		if ( $errors == "" ) {
+			$sql_command = "SELECT * FROM " . $table . " WHERE registrar = ?  AND id != ?";
+			$stm = $link->prepare($sql_command);
+			if ( $stm->execute( array($registrar, $id) ) === false )
+				die('Failed to issue query, error message : ' . print_r($stm->errorInfo(), true));
+			$row = $stm->fetchAll();
+
+			if ( count($row)>0 ) {
+				$errors = "Duplicate registrar";
+			} else {
+				$sql_command = "UPDATE " . $table . " SET " .
+							 "registrar=?, " .
+							 "proxy=?, " .
+							 "registrar_mode=?, " .
+							 "aor=?, " .
+							 "third_party_registrant=?, " .
+							 "username=?, " .
+							 "password=?, " .
+							 "binding_uri=?, " .
+							 "binding_params=?, " .
+							 "expiry=?, " .
+							 "forced_socket=?, " .
+							 "cluster_shtag=? " .
+							 "WHERE id=?";
+				$stm = $link->prepare($sql_command);
+				if ($stm === false) {
+					die('Failed to issue query ['.$sqlL_command.'], error message : ' . print_r($link->errorInfo(), true));
+				}
+				if ( $stm->execute( array($registrar, $proxy, $registrar_mode, $aor, $third_party_registrant, $username, $password,
+										  $binding_uri, $binding_params, $expiry, $forced_socket, $cluster_shtag,
+										  $id) ) === false ) {
+					$errors = "Updating SIP Trunk record failed: ".print_r($stm->errorInfo(), true);
+				} else {
+					$info = "The SIP Trunk record was modified";
+				}
+			}
+		}
+	} else {
+
+		$errors = "User with Read-Only Rights";
+	}
+}
+#################
+# end modify	#
+#################
+
+################
+# start search #
+################
+if ( $action == "sip_trunk_search" ) {
+	$_SESSION[$current_page]=1;
+	extract($_GET);
+	extract($_POST);
+
+	if ( $show_all == "Show All" ) {
+		$_SESSION['sip_trunk_registrar'] = "";
+		$_SESSION['sip_trunk_proxy'] = "";
+		$_SESSION['sip_trunk_aor'] = "";
+	} else if( $search == "Search" ) {
+		if (isset($_GET['sip_trunk_registrar']))
+			$_SESSION['sip_trunk_registrar']=$_GET['sip_trunk_registrar'];
+		else if (isset($_POST['sip_trunk_registrar']))
+			$_SESSION['sip_trunk_registrar']=$_POST['sip_trunk_registrar'];
+		else
+			$_SESSION['sip_trunk_registrar']="";
+		if (isset($_GET['sip_trunk_proxy']))
+			$_SESSION['sip_trunk_proxy']=$_GET['sip_trunk_proxy'];
+		else if (isset($_POST['sip_trunk_proxy']))
+			$_SESSION['sip_trunk_proxy']=$_POST['sip_trunk_proxy'];
+		else
+			$_SESSION['sip_trunk_proxy']="";
+		if (isset($_GET['sip_trunk_aor']))
+			$_SESSION['sip_trunk_aor']=$_GET['sip_trunk_aor'];
+		else if (isset($_POST['sip_trunk_aor']))
+			$_SESSION['sip_trunk_aor']=$_POST['sip_trunk_aor'];
+		else
+			$_SESSION['sip_trunk_aor']="";
+	}
+}
+##############
+# end search #
+##############
+
+##############
+# start main #
+##############
+
+require("template/" . $page_id . ".main.php");
+
+if ( !empty($errors) ) {
+	echo "Error stack: ";
+	print_r($errors);
+}
+
+require("template/footer.php");
+exit();
+
+##############
+# end main   #
+##############
+?>

--- a/web/tools/system/sip_trunk/template/footer.php
+++ b/web/tools/system/sip_trunk/template/footer.php
@@ -1,0 +1,11 @@
+  </td>
+ </tr>
+</table>
+</center>
+</body>
+
+</html>
+<?php
+ $_SESSION['user_active_tool'] = "sip_trunk";
+ $_SESSION['user_active_page'] = $page_name;
+?>

--- a/web/tools/system/sip_trunk/template/header.php
+++ b/web/tools/system/sip_trunk/template/header.php
@@ -1,0 +1,47 @@
+<?php
+/*
+* Copyright (C) 2019 OpenSIPS Project
+*
+* This file is part of opensips-cp, a free Web Control Panel Application for
+* OpenSIPS SIP server.
+*
+* opensips-cp is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* opensips-cp is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*/
+
+require_once("../../../../config/session.inc.php");
+require_once("../../../../config/tools/system/sip_trunk/db.inc.php");
+require_once("../../../../config/db.inc.php");
+require_once("../../../../config/tools/system/sip_trunk/local.inc.php");
+
+$page_name = basename($_SERVER['PHP_SELF']);
+$page_id = substr($page_name, 0, strlen($page_name) - 4);
+$no_result = "No Data Found.";
+?>
+
+<html>
+
+<head>
+ <link href="../../../style_tools.css" type="text/css" rel="StyleSheet">
+</head>
+
+<body bgcolor="#e9ecef">
+<center>
+<table width="90%" cellpadding="5" cellspacing="5" border="0">
+ <tr  valign="top" height="20">
+  <td><?php require("template/menu.php") ?></td>
+ </tr>
+ <tr valign="top" align="center">
+  <td>
+   <img src="../../../images/share/spacer.gif" width="10" height="5"><br>

--- a/web/tools/system/sip_trunk/template/menu.php
+++ b/web/tools/system/sip_trunk/template/menu.php
@@ -1,0 +1,51 @@
+<?php
+ /*
+ * Copyright (C) 2019 OpenSIPS Project
+ *
+ * This file is part of opensips-cp, a free Web Control Panel Application for
+ * OpenSIPS SIP server.
+ *
+ * opensips-cp is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * opensips-cp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+?>
+
+<table width="100%" border="0" cellpadding="0" cellspacing="0" align="center">
+  <tr>
+    <td class="breadcrumb">
+        <?php print "System / SIP Trunk / ".$_SESSION['permission'];?>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" valign="middle">
+      <div class="menuItems">
+        <?php
+        $first_item = true;
+        if ( !isset($config->menu_item) )
+            echo('<font class="menuItemSelect">&nbsp;</font>');
+        else
+            while ( list($key,$value) = each($config->menu_item) ) {
+                if ( !$first_item )
+                    echo('&nbsp;&nbsp;|&nbsp;&nbsp;');
+                if ( $page_name != $config->menu_item[$key]["0"])
+                    echo('<a href="'.$config->menu_item[$key]["0"].'" class="menuItem">'.$config->menu_item[$key]["1"].'</a>');
+                else
+                    echo('<a href="'.$config->menu_item[$key]["0"].'" class="menuItemSelect">'.$config->menu_item[$key]["1"].'</a>');
+                $first_item = false;
+            }
+        ?>
+      </div>
+    </td>
+  </tr>
+</table>

--- a/web/tools/system/sip_trunk/template/sip_trunk.add.php
+++ b/web/tools/system/sip_trunk/template/sip_trunk.add.php
@@ -20,9 +20,14 @@
 * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
+if ( isset($_GET['id']) )
+	$id = $_GET['id'];
+else
+	$id = "";
+
 ?>
-<form action="<?=$page_name?>?action=add_verify&clone=<?=$_GET['clone']?>&id=<?=$_GET['id']?>" method="post">
-	<table width="400" cellspacing="2" cellpadding="2" border="0">
+<form action="<?=$page_name?>?action=add_verify&clone=<?=$_GET['clone']?>&id=<?=$id?>" method="post">
+	<table width="200" cellspacing="2" cellpadding="2" border="0">
 
 	<tr align="center">
 		<td colspan="2" class="mainTitle">
@@ -34,6 +39,7 @@
 	# populate the initial values for the form
 	$ds_form['registrar'] = null;
 	$ds_form['proxy'] = null;
+	$ds_form['registrar_mode'] = null;
 	$ds_form['aor'] = null;
 	$ds_form['third_party_registrant'] = null;
 	$ds_form['username'] = null;
@@ -48,15 +54,15 @@
 	?>
 
 	<tr>
-	    <td colspan="2">
-		    <table cellspacing=20>
-		        <tr>
-		            <td class="dataRecord" align="right" width="50%">
-		                <input type="submit" name="add" disabled=true value="Add" class="formButton"></td>
-		            <td class="dataRecord" align="left" width="50%"><?php print_back_input(); ?></td>
-		        </tr>
-		    </table>
-	    </td>
+		<td colspan="2">
+			<table cellspacing=20>
+				<tr>
+					<td class="dataRecord" align="right" width="50%">
+						<input type="submit" name="add" disabled=true value="Add" class="formButton"></td>
+					<td class="dataRecord" align="left" width="50%"><?php print_back_input(); ?></td>
+				</tr>
+			</table>
+		</td>
 	</tr>
 
 	</table>

--- a/web/tools/system/sip_trunk/template/sip_trunk.add.php
+++ b/web/tools/system/sip_trunk/template/sip_trunk.add.php
@@ -1,0 +1,63 @@
+<?php
+/*
+* Copyright (C) 2019 OpenSIPS Project
+*
+* This file is part of opensips-cp, a free Web Control Panel Application for
+* OpenSIPS SIP server.
+*
+* opensips-cp is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* opensips-cp is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*/
+
+?>
+<form action="<?=$page_name?>?action=add_verify&clone=<?=$_GET['clone']?>&id=<?=$_GET['id']?>" method="post">
+	<table width="400" cellspacing="2" cellpadding="2" border="0">
+
+	<tr align="center">
+		<td colspan="2" class="mainTitle">
+			Add new SIP Trunk
+		</td>
+	</tr>
+
+	<?php
+	# populate the initial values for the form
+	$ds_form['registrar'] = null;
+	$ds_form['proxy'] = null;
+	$ds_form['aor'] = null;
+	$ds_form['third_party_registrant'] = null;
+	$ds_form['username'] = null;
+	$ds_form['password'] = null;
+	$ds_form['binding_uri'] = null;
+	$ds_form['binding_params'] = null;
+	$ds_form['expiry'] = null;
+	$ds_form['forced_socket'] = null;
+	$ds_form['cluster_shtag'] = null;
+
+	require("sip_trunk.form.php");
+	?>
+
+	<tr>
+	    <td colspan="2">
+		    <table cellspacing=20>
+		        <tr>
+		            <td class="dataRecord" align="right" width="50%">
+		                <input type="submit" name="add" disabled=true value="Add" class="formButton"></td>
+		            <td class="dataRecord" align="left" width="50%"><?php print_back_input(); ?></td>
+		        </tr>
+		    </table>
+	    </td>
+	</tr>
+
+	</table>
+</form>

--- a/web/tools/system/sip_trunk/template/sip_trunk.clone.php
+++ b/web/tools/system/sip_trunk/template/sip_trunk.clone.php
@@ -1,0 +1,91 @@
+<?php
+/*
+* Copyright (C) 2019 OpenSIPS Project
+*
+* This file is part of opensips-cp, a free Web Control Panel Application for
+* OpenSIPS SIP server.
+*
+* opensips-cp is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* opensips-cp is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*/
+
+if ( isset($_GET['clone']) )
+	$clone = $_GET['clone'];
+else
+	$clone = 0;
+
+if ( $clone == "1" ) {
+	$id = $_GET['id'];
+
+	$sql = "select * from " . $table . " where id=?";
+		$stm = $link->prepare($sql);
+	if ($stm === FALSE)
+		die('Failed to issue query, error message : ' . print_r($link->errorInfo(), true));
+	$stm->execute( array($id) );
+	$resultset= $stm->fetchAll(PDO::FETCH_ASSOC);
+
+	$registrar = $resultset[0]['registrar'];
+	$proxy = $resultset[0]['proxy'];
+	$aor =$resultset[0]['aor'];
+	$third_party_registrant =$resultset[0]['third_party_registrant'];
+	$username =$resultset[0]['username'];
+	$password  =$resultset[0]['password'];
+	$binding_uri = $resultset[0]['binding_uri'];
+	$binding_params = $resultset[0]['binding_params'];
+	$expiry = $resultset[0]['expiry'];
+	$forced_socket = $resultset[0]['forced_socket'];
+	$cluster_shtag = $resultset[0]['cluster_shtag'];
+}
+
+?>
+<form action="<?=$page_name?>?action=clone&clone=<?=$_GET['clone']?>&id=<?=$_GET['id']?>" method="post">
+	<table width="400" cellspacing="2" cellpadding="2" border="0">
+
+	<tr align="center">
+		<td colspan="2" class="mainTitle">
+			Clone given SIP Trunk
+		</td>
+	</tr>
+
+	<?php
+	# populate the initial values for the form
+	$ds_form['registrar'] = $registrar;
+	$ds_form['proxy'] = $proxy;
+	$ds_form['aor'] = $aor;
+	$ds_form['third_party_registrant'] = $third_party_registrant;
+	$ds_form['username'] = $username;
+	$ds_form['password'] = $password;
+	$ds_form['binding_uri'] = $binding_uri;
+	$ds_form['binding_params'] = $binding_params;
+	$ds_form['expiry'] = $expiry;
+	$ds_form['forced_socket'] = $forced_socket;
+	$ds_form['cluster_shtag'] = $cluster_shtag;
+
+	require("sip_trunk.form.php");
+	?>
+
+	<tr>
+	    <td colspan="2">
+		    <table cellspacing=20>
+		        <tr>
+		            <td class="dataRecord" align="right" width="50%">
+		                <input type="submit" name="add_verify" disabled=true value="Clone" class="formButton"></td>
+		            <td class="dataRecord" align="left" width="50%"><?php print_back_input(); ?></td>
+		        </tr>
+		    </table>
+	    </td>
+	</tr>
+
+	</table>
+</form>

--- a/web/tools/system/sip_trunk/template/sip_trunk.edit.php
+++ b/web/tools/system/sip_trunk/template/sip_trunk.edit.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Copyright (C) 2019 OpenSIPS Project
+ *
+ * This file is part of opensips-cp, a free Web Control Panel Application for
+ * OpenSIPS SIP server.
+ *
+ * opensips-cp is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * opensips-cp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+?>
+
+<form action="<?=$page_name?>?action=modify&id=<?=$_GET['id']?>" method="post">
+<table width="400" cellspacing="2" cellpadding="2" border="0">
+
+<?php
+if ( isset($form_error) ) {
+	echo('   <tr align="center">');
+	echo('       <td colspan="2" class="dataRecord"><div class="formError">'.$form_error.'</div></td>');
+	echo('   </tr>');
+}
+$id = $_GET['id'];
+
+$sql_command = "select * from ".$table." where id=?";
+$stm = $link->prepare($sql_command);
+if ($stm->execute(array($id)) === false)
+	die('Failed to issue query, error message : ' . print_r($stm->errorInfo(), true));
+$resultset = $stm->fetchAll(PDO::FETCH_ASSOC);
+
+$index_row=0;
+?>
+    <table width="350" cellspacing="2" cellpadding="2" border="0">
+	    <tr align="center">
+		     <td colspan="2" class="mainTitle">Edit SIP Trunk</td>
+	    </tr>
+<?php
+	# populate row values to the form fields
+	$ds_form['registrar'] = $resultset[0]['registrar'];
+	$ds_form['proxy'] = $resultset[0]['proxy'];
+	$ds_form['aor'] = $resultset[0]['aor'];
+	$ds_form['third_party_registrant'] = $resultset[0]['third_party_registrant'];
+	$ds_form['username'] = $resultset[0]['username'];
+	$ds_form['password'] = $resultset[0]['password'];
+	$ds_form['binding_uri'] = $resultset[0]['binding_uri'];
+	$ds_form['binding_params'] = $resultset[0]['binding_params'];
+	$ds_form['expiry'] = $resultset[0]['expiry'];
+	$ds_form['forced_socket'] = $resultset[0]['forced_socket'];
+	$ds_form['cluster_shtag'] = $resultset[0]['cluster_shtag'];
+
+	require("sip_trunk.form.php");
+?>
+
+	    <tr>
+		    <td colspan="2">
+			    <table cellspacing=20>
+				    <tr>
+					    <td class="dataRecord" align="right" width="50%">
+					       <input type="submit" name="save" value="Save" class="formButton"></td>
+					    <td class="dataRecord" align="left" width="50%"><?php print_back_input(); ?></td>
+				    </tr>
+			    </table>
+		    </td>
+	    </tr>
+    </table>
+</form>

--- a/web/tools/system/sip_trunk/template/sip_trunk.edit.php
+++ b/web/tools/system/sip_trunk/template/sip_trunk.edit.php
@@ -6,7 +6,7 @@
  * OpenSIPS SIP server.
  *
  * opensips-cp is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * it under the terms of the GNU GenPeral Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
  *
@@ -40,14 +40,15 @@ $resultset = $stm->fetchAll(PDO::FETCH_ASSOC);
 
 $index_row=0;
 ?>
-    <table width="350" cellspacing="2" cellpadding="2" border="0">
-	    <tr align="center">
-		     <td colspan="2" class="mainTitle">Edit SIP Trunk</td>
-	    </tr>
+	<table width="350" cellspacing="2" cellpadding="2" border="0">
+		<tr align="center">
+			 <td colspan="2" class="mainTitle">Edit SIP Trunk</td>
+		</tr>
 <?php
 	# populate row values to the form fields
 	$ds_form['registrar'] = $resultset[0]['registrar'];
 	$ds_form['proxy'] = $resultset[0]['proxy'];
+	$ds_form['registrar_mode'] = $resultset[0]['registrar_mode'];
 	$ds_form['aor'] = $resultset[0]['aor'];
 	$ds_form['third_party_registrant'] = $resultset[0]['third_party_registrant'];
 	$ds_form['username'] = $resultset[0]['username'];
@@ -61,16 +62,16 @@ $index_row=0;
 	require("sip_trunk.form.php");
 ?>
 
-	    <tr>
-		    <td colspan="2">
-			    <table cellspacing=20>
-				    <tr>
-					    <td class="dataRecord" align="right" width="50%">
-					       <input type="submit" name="save" value="Save" class="formButton"></td>
-					    <td class="dataRecord" align="left" width="50%"><?php print_back_input(); ?></td>
-				    </tr>
-			    </table>
-		    </td>
-	    </tr>
-    </table>
+		<tr>
+			<td colspan="2">
+				<table cellspacing=20>
+					<tr>
+						<td class="dataRecord" align="right" width="50%">
+						   <input type="submit" name="save" value="Save" class="formButton"></td>
+						<td class="dataRecord" align="left" width="50%"><?php print_back_input(); ?></td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
 </form>

--- a/web/tools/system/sip_trunk/template/sip_trunk.form.php
+++ b/web/tools/system/sip_trunk/template/sip_trunk.form.php
@@ -23,37 +23,53 @@
 require("../../../common/forms.php");
 
 form_generate_input_text("Registrar", "The URI pointing to the SIP Trunk registrar (eg: sip:sip-trunk.telekom.de)",
-                         "registrar", "n", $ds_form['registrar'], 255, "^" . $re_sip_uris . "$");
+						 "registrar", "n", $ds_form['registrar'], 255, "^" . $re_sip_uris . "(:(5060|5061)?)?$");
 
 form_generate_input_text("Proxy", "The URI pointing to the SIP proxy of the registrar (eg: sip:reg.sip-trunk.telekom.de)",
-                         "proxy", "n", $ds_form['proxy'], 255, "^" . $re_sip_uris . "$");
+						 "proxy", "n", $ds_form['proxy'], 255, "^" . $re_sip_uris . "(:(5060|5061)?)?$");
 
-form_generate_input_text("Address of registrant", "Address associated to the given SIP registrant (eg: 'PSTN-Nr'@sip-trunk.telekom.de)",
-                         "aor", "n", $ds_form['aor'], 255, "^" . $re_pstn . "@" . $re_fqdn . "$");
+// registration mode: get key/value pairs from config file 'local.inc.php'
+$keys = array();
+$values = array();
+foreach($config->registration_mode as $element) {
+	array_push($keys, $element[0]);
+	array_push($values, $element[1]);
+}
+
+// server side: define the selection box
+form_generate_select("Registration Mode", "What mode is used to register the SIP Trunk at the registrar",
+					 "registrar_mode", 128, $ds_form['registrar_mode'],
+					 $keys, $values, "aor" );
+
+
+// server side: define the input field, client side: preset defaults for tooltip_text and re values
+form_generate_input_text("Address of Registrant", "",
+						 "aor", "n", $ds_form['aor'], 255, "");
 
 form_generate_input_text("Address of 3rd party registrant", "Address associated to the SIP of the 3rd party registrant",
-                         "third_party_registrant", "y", $ds_form['third_party_registrant'], 255, "^" . $re_pstn . "@" . $re_fqdn . "$");
+						 "third_party_registrant", "y", $ds_form['third_party_registrant'], 255, "^" . $re_pstn . "@" . $re_fqdn . "$");
 
 form_generate_input_text("Username", "The username of the registrant",
-                         "username", "n", $ds_form['username'], 64, "^[^@]+(.{8,})$");
-                         //"^([a-z][A-Z][0-9])+$");
+						 "username", "n", $ds_form['username'], 64, "^[^@]+(.{8,})$");
+						 //"^([a-z][A-Z][0-9])+$");
 
 form_generate_input_text("Password", "The password of the registrant",
-                         "password", "n", $ds_form['password'], 64, "^[^@]+(.{7,})$");
+						 "password", "n", $ds_form['password'], 64, "^[^@]+(.{7,})$");
 
-form_generate_input_text("Binding URI", "The URI the registrar will binding the registrant to (e.g: sips:'PSTN-Nr'@sip-trunk.telekom.de",
-                         "binding_uri", "y", $ds_form['binding_uri'], 255, "^(sip(s)?:" . $re_pstn . "@" . $re_fqdn . "$");
+form_generate_input_text("Binding URI", "The URI the registrar will binding the registrant to (e.g: sips:'PSTN-Nr'@sip-trunk.telekom.de:5060",
+						 //"binding_uri", "n", $ds_form['binding_uri'], 255, "^(sip(s)?:" . $re_pstn . "@" . $re_fqdn . "(:(5060|5061)?)?$");
+						 "binding_uri", "n", $ds_form['binding_uri'], 255, "^sip(s)?:" . $re_pstn . "@" . $re_uris . "(:(5060|5061)?)?$");
 
 form_generate_input_text("Binding Parameters", "Binding Parameters",
-                         "binding_params", "y", $ds_form['binding_params'], 64 , "^sip:([0-9][a-Z]+)$");
+						 "binding_params", "y", $ds_form['binding_params'], 64 , "^sip:([0-9][a-Z]+)$");
 
 form_generate_input_text("Expriry", "Timeout value to revalidated the authentication (in seconds)",
-                         "expiry", "y", $ds_form['expiry'], 16, "^([0-9]+)$");
+						 "expiry", "y", $ds_form['expiry'], 16, "^([0-9]+)$");
 
 form_generate_input_text("Forced Socket", "The OpenSIPS network listener (as proto:ip:port) to be used for reach the registrar (leave empty if not needed)",
-                         "forced_socket", "y", $ds_form['forced_socket'], 64,  "^(tcp|udp):" . $re_ips . "(:[0-9]+)?$");
+						 "forced_socket", "y", $ds_form['forced_socket'], 64,  "^(tcp|udp):" . $re_ips . "(:[0-9]+)?$");
 
 form_generate_input_text("Cluster shared tag", "Shared tag inside the cluster",
-                         "cluster_shtag", "y", $ds_form['cluster_shtag'], 64, "^([0-9]+)$");
+						 "cluster_shtag", "y", $ds_form['cluster_shtag'], 64, "^([0-9]+)$");
 
 ?>

--- a/web/tools/system/sip_trunk/template/sip_trunk.form.php
+++ b/web/tools/system/sip_trunk/template/sip_trunk.form.php
@@ -1,0 +1,59 @@
+<?php
+/*
+* Copyright (C) 2017 OpenSIPS Project
+*
+* This file is part of opensips-cp, a free Web Control Panel Application for
+* OpenSIPS SIP server.
+*
+* opensips-cp is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* opensips-cp is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+require("../../../common/forms.php");
+
+form_generate_input_text("Registrar", "The URI pointing to the SIP Trunk registrar (eg: sip:sip-trunk.telekom.de)",
+                         "registrar", "n", $ds_form['registrar'], 255, "^" . $re_sip_uris . "$");
+
+form_generate_input_text("Proxy", "The URI pointing to the SIP proxy of the registrar (eg: sip:reg.sip-trunk.telekom.de)",
+                         "proxy", "n", $ds_form['proxy'], 255, "^" . $re_sip_uris . "$");
+
+form_generate_input_text("Address of registrant", "Address associated to the given SIP registrant (eg: 'PSTN-Nr'@sip-trunk.telekom.de)",
+                         "aor", "n", $ds_form['aor'], 255, "^" . $re_pstn . "@" . $re_fqdn . "$");
+
+form_generate_input_text("Address of 3rd party registrant", "Address associated to the SIP of the 3rd party registrant",
+                         "third_party_registrant", "y", $ds_form['third_party_registrant'], 255, "^" . $re_pstn . "@" . $re_fqdn . "$");
+
+form_generate_input_text("Username", "The username of the registrant",
+                         "username", "n", $ds_form['username'], 64, "^[^@]+(.{8,})$");
+                         //"^([a-z][A-Z][0-9])+$");
+
+form_generate_input_text("Password", "The password of the registrant",
+                         "password", "n", $ds_form['password'], 64, "^[^@]+(.{7,})$");
+
+form_generate_input_text("Binding URI", "The URI the registrar will binding the registrant to (e.g: sips:'PSTN-Nr'@sip-trunk.telekom.de",
+                         "binding_uri", "y", $ds_form['binding_uri'], 255, "^(sip(s)?:" . $re_pstn . "@" . $re_fqdn . "$");
+
+form_generate_input_text("Binding Parameters", "Binding Parameters",
+                         "binding_params", "y", $ds_form['binding_params'], 64 , "^sip:([0-9][a-Z]+)$");
+
+form_generate_input_text("Expriry", "Timeout value to revalidated the authentication (in seconds)",
+                         "expiry", "y", $ds_form['expiry'], 16, "^([0-9]+)$");
+
+form_generate_input_text("Forced Socket", "The OpenSIPS network listener (as proto:ip:port) to be used for reach the registrar (leave empty if not needed)",
+                         "forced_socket", "y", $ds_form['forced_socket'], 64,  "^(tcp|udp):" . $re_ips . "(:[0-9]+)?$");
+
+form_generate_input_text("Cluster shared tag", "Shared tag inside the cluster",
+                         "cluster_shtag", "y", $ds_form['cluster_shtag'], 64, "^([0-9]+)$");
+
+?>

--- a/web/tools/system/sip_trunk/template/sip_trunk.main.php
+++ b/web/tools/system/sip_trunk/template/sip_trunk.main.php
@@ -1,0 +1,285 @@
+<?php
+/*
+ * Copyright (C) 2019 OpenSIPS Project
+ *
+ * This file is part of opensips-cp, a free Web Control Panel Application for
+ * OpenSIPS SIP server.
+ *
+ * opensips-cp is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * opensips-cp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+$sql_search = "";
+$sql_values = array();
+
+if ( isset($_SESSION['sip_trunk_registrar']) )
+    $search_registrar = $_SESSION['sip_trunk_registrar'];
+else
+    $search_registrar = "";
+if ( isset($_SESSION['sip_trunk_proxy']) )
+    $search_proxy = $_SESSION['sip_trunk_proxy'];
+else
+    $search_proxy = "";
+if ( isset($_SESSION['sip_trunk_aor']) )
+    $search_aor = $_SESSION['sip_trunk_aor'];
+else
+    $search_aor = "";
+
+if( $search_registrar != "") {
+    $sql_search .= " and registrar=?";
+    array_push( $sql_values, $search_registrar);
+}
+if( $search_proxy != "") {
+    $sql_search .= " and proxy like ?";
+    array_push( $sql_values, "%".$search_proxy."%");
+}
+if( $search_aor != "") {
+    $sql_search .= " and aor like ?";
+    array_push( $sql_values, "%".$search_aor."%");
+}
+
+if( !$_SESSION['read_only'] ) {
+    $colspan = 14;
+}else{
+    $colspan = 12;
+}
+?>
+
+<div id="dialog" class="dialog" style="display:none"></div>
+<div onclick="closeDialog();" id="overlay" style="display:none"></div>
+<div id="content" style="display:none"></div>
+
+<form action="<?=$page_name?>?action=sip_trunk_search" method="post">
+
+    <table width="50%" cellspacing="2" cellpadding="2" border="0">
+	<tr>
+	    <td class="searchRecord">Registrar</td>
+	    <td class="searchRecord" width="200"><input type="text" name="sip_trunk_registrar"
+							value="<?=$search_registrar?>" class="searchInput"></td>
+	</tr>
+	<tr>
+	    <td class="searchRecord">Proxy</td>
+	    <td class="searchRecord" width="200"><input type="text" name="sip_trunk_proxy"
+							value="<?=$search_proxy?>" maxlength="16" class="searchInput"></td>
+	</tr>
+	<tr>
+	    <td class="searchRecord">Address of Registrant</td>
+	    <td class="searchRecord" width="200"><input type="text" name="sip_trunk_aor"
+							value="<?=$search_aor?>" maxlength="128" class="searchInput"></td>
+	</tr>
+	<tr height="10">
+	    <td colspan="2" class="searchRecord border-bottom-devider" align="center">
+		<input type="submit" name="search" value="Search" class="searchButton">&nbsp;&nbsp;&nbsp;
+		<input type="submit" name="show_all" value="Show All" class="searchButton"></td>
+	</tr>
+    </table>
+</form>
+
+
+<?php if ( !$_SESSION['read_only'] ) { ?>
+    <form action="<?=$page_name?>?action=add&clone=0" method="post">
+	<input type="submit" name="add_new" value="Add SIP Trunk" class="formButton"> &nbsp;&nbsp;&nbsp;
+	<!--input type="submit" name="refresh" value="Refresh from Server" class="searchButton"--> &nbsp;&nbsp;&nbsp;
+	<input onclick="apply_changes()" name="reload" class="formButton" value="Reload on Server" type="button"/>
+    </form>
+<?php } ?>
+
+<table class="ttable" width="95%" cellspacing="2" cellpadding="2" border="0">
+    <tr align="center">
+	<th class="listTitle">Registrar</th>
+	<th class="listTitle">Proxy</th>
+	<th class="listTitle">Address of Registrant</th>
+	<th class="listTitle">3rd Party Registrant</th>
+	<th class="listTitle">Username</th>
+	<th class="listTitle">Password</th>
+	<th class="listTitle">Binding URI</th>
+	<th class="listTitle">Binding Params</th>
+	<th class="listTitle">Expiry</th>
+	<th class="listTitle">Forced Socket</th>
+	<th class="listTitle">Cluster Share-Tag</th>
+	<?php
+	if ( !$_SESSION['read_only'] ) {
+	    echo('<th class="listTitle">Edit</th>
+		<th class="listTitle">Delete</th>
+		<th class="listTitle">Clone</th>');
+	}
+	?>
+    </tr>
+
+    <?php
+    if ( $sql_search == "" ) {
+	$sql_command = "select * from " . $table . " where (1=1) order by registrar, proxy, aor asc";
+	$sql_count = "select count(*) from " . $table . " where (1=1)";
+    }
+    else {
+	$sql_command = "select * from ".$table." where (1=1) " . $sql_search . " order by registrar, proxy, aor asc";
+	$sql_count = "select count(*) from " . $table . " where (1=1) " . $sql_search;
+    }
+
+    $stm = $link->prepare($sql_count);
+    if ( $stm === FALSE ) {
+	die('Failed to issue query [' . $sql_count . '], error message : ' . $link->errorInfo()[2]);
+    }
+    $stm->execute( $sql_values );
+    $data_no = $stm->fetchColumn(0);
+
+    if ( $data_no == 0 )
+	echo('<tr><td colspan="' . $colspan . '" class="rowEven" align="center"><br>' .
+	     $no_result . '<br><br></td></tr>');
+    else {
+	$sip_trunk_state = array();
+	$sip_trunk_res = array();
+	$sip_trunk_auto = array();
+
+	/*
+	   // get in memory status for the entries we want to list
+	   $mi_connectors=get_proxys_by_assoc_id($talk_to_this_assoc_id);
+	   $message = mi_command('sip_trunk_list', $mi_connectors[0], $errors, $status);
+
+	   $sip_trunk_state = array();
+	   $sip_trunk_res = array();
+	   $sip_trunk_auto = array();
+
+	   $message = json_decode($message,true);
+	   $message = $message['Destination'];
+	   for ( $i=0; $i<count($message); $i++ ) {
+	   $id		= $message[$i]['attributes']['id'];
+
+	   $resource="";
+	   $res = $message[$i]['children']['Resources']['children']['Resource'];
+	   for ( $j=0; $j<count($res); $j++ ) {
+	   $resource .= "<tr>";
+	   $resource .= "<td>".$res[$j]['value']."=".$res[$j]['attributes']['load']."/".$res[$j]['attributes']['max']."</td>";
+	   $resource .= "</tr>";
+	   }
+	   $sip_trunk_res[$id] = "<table class=\"pagingtable\" width=\"100%!important;\" cellspacing=\"2\"
+	   cellpadding=\"2\" border=\"0\">".$resource."</table>";
+	   //$sip_trunk_res[$id] = "<table style=\"width:100%!important;\">".$resource."</table>";
+	   $sip_trunk_state[$id] = ($message[$i]['attributes']['enabled']=="yes")?"enabled":"disabled";
+	   $sip_trunk_auto[$id] = $message[$i]['attributes']['auto-reenable'];
+	   }
+	 */
+
+	$res_no = $config->results_per_page;
+	$page = $_SESSION[$current_page];
+	$page_no = ceil( $data_no/$res_no );
+	if ( $page > $page_no ) {
+	    $page = $page_no;
+	    $_SESSION[$current_page] = $page;
+	}
+
+	$start_limit = ( $page-1 ) * $res_no;
+	if ( $start_limit == 0 )
+	    $sql_command .= " limit " . $res_no;
+	else
+	    $sql_command .= " limit " . $res_no . " OFFSET " . $start_limit;
+
+	// pepare SQL statement
+	$stm = $link->prepare($sql_command);
+	if ( $stm === FALSE ) {
+	    die('Failed to issue query [' . $sql_command . '], error message : ' . $link->errorInfo()[2]);
+	}
+
+	// execute the SQL statement and fetch results
+	$stm->execute( $sql_values );
+	$result = $stm->fetchAll(PDO::FETCH_ASSOC);
+
+	// display the resulting rows in the table
+	$index_row = 0;
+	for ( $i=0; count($result)>$i; $i++ )
+	{
+	    $index_row++;
+	    $id = $result[$i]['id'];
+
+	    if ( $index_row%2 == 1 )
+		$row_style="rowOdd";
+	    else
+		$row_style="rowEven";
+
+	    /* if the resources were not fetched via MI, used
+	       the DB values */
+	    //if ( $sip_trunk_res[$id] == NULL || $sip_trunk_res[$id] == "" )
+	    //	$sip_trunk_res[$id] = $result[$i]['resources'];
+
+	    if( !$_SESSION['read_only'] ) {
+		$edit_link = '<a href="'.$page_name.'?action=edit&clone=0&id='.$result[$i]['id'].'"><img src="../../../images/share/edit.png" border="0"></a>';
+		$delete_link='<a href="'.$page_name.'?action=delete&clone=0&id='.$result[$i]['id'].'" onclick="return confirmDelete()"><img src="../../../images/share/delete.png" border="0"></a>';
+		$clone_link='<a href="'.$page_name.'?action=clone&clone=1&id='.$result[$i]['id'].'"><img src="../../../images/share/clone.gif" border="0"></a>';
+	    }
+    ?>
+    <tr>
+	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['registrar']?></td>
+	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['proxy']?></td>
+	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['aor']?></td>
+	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['third_party_registrant']?></td>
+	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['username']?></td>
+	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['password']?></td>
+	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['binding_uri']?></td>
+	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['binding_params']?></td>
+	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['expiry']?></td>
+	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['forced_socket']?></td>
+	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['cluster_shtag']?></td>
+	<?php
+	if ( !$_SESSION['read_only'] ) {
+	    echo('<td class="'.$row_style.'Img" align="center">'.$edit_link.'</td>
+	      <td class="'.$row_style.'Img" align="center">'.$delete_link.'</td>
+	      <td class="'.$row_style.'Img" align="center">'.$clone_link.'</td>');
+	}
+	?>
+    </tr>
+    <?php
+    }
+    }
+    ?>
+    <tr>
+	<th colspan="<?=$colspan?>">
+	    <table class="pagingTable">
+		<tr>
+		    <th align="left">Page:
+			<?php
+			if ( $data_no == 0 )
+			    echo('<font class="pageActive">0</font>&nbsp;');
+			else {
+			    $max_pages = $config->results_page_range;
+			    // start page
+			    if ( $page % $max_pages == 0 )
+				$start_page = $page - $max_pages + 1;
+			    else
+				$start_page = $page - ($page % $max_pages) + 1;
+			    // end page
+			    $end_page = $start_page + $max_pages - 1;
+			    if ( $end_page > $page_no )
+				$end_page = $page_no;
+			    // back block
+			    if ( $start_page != 1 )
+				echo('&nbsp;<a href="'.$page_name.'?page='.($start_page-$max_pages).'" class="menuItem"><b>&lt;&lt;</b></a>&nbsp;');
+			    // current pages
+			    for ( $i = $start_page; $i <= $end_page; $i++ )
+				if ( $i == $page )
+				    echo('<font class="pageActive">'.$i.'</font>&nbsp;');
+			    else
+				echo('<a href="'.$page_name.'?page='.$i.'" class="pageList">'.$i.'</a>&nbsp;');
+			    // next block
+			    if ($end_page != $page_no)
+				echo('&nbsp;<a href="'.$page_name.'?page='.($start_page+$max_pages).'" class="menuItem"><b>&gt;&gt;</b></a>&nbsp;');
+			}
+			?>
+		    </th>
+		    <th align="right">Total Records: <?=$data_no?>&nbsp;</th>
+		</tr>
+	    </table>
+	</th>
+    </tr>
+</table>
+<br>

--- a/web/tools/system/sip_trunk/template/sip_trunk.main.php
+++ b/web/tools/system/sip_trunk/template/sip_trunk.main.php
@@ -50,9 +50,9 @@ if( $search_aor != "") {
 }
 
 if( !$_SESSION['read_only'] ) {
-    $colspan = 14;
+    $colspan = 15;
 }else{
-    $colspan = 12;
+    $colspan = 13;
 }
 ?>
 
@@ -99,6 +99,7 @@ if( !$_SESSION['read_only'] ) {
     <tr align="center">
 	<th class="listTitle">Registrar</th>
 	<th class="listTitle">Proxy</th>
+	<th class="listTitle">Registrar Mode</th>
 	<th class="listTitle">Address of Registrant</th>
 	<th class="listTitle">3rd Party Registrant</th>
 	<th class="listTitle">Username</th>
@@ -221,6 +222,7 @@ if( !$_SESSION['read_only'] ) {
     <tr>
 	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['registrar']?></td>
 	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['proxy']?></td>
+	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['registrar_mode']?></td>
 	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['aor']?></td>
 	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['third_party_registrant']?></td>
 	<td class="<?=$row_style?>">&nbsp;<?=$result[$i]['username']?></td>

--- a/web/tools/system/sip_trunk/tool.name
+++ b/web/tools/system/sip_trunk/tool.name
@@ -1,0 +1,1 @@
+Sip Trunk


### PR DESCRIPTION
## Goal ##

offer a working form that will let you select between available registration modes. The user will fill in field `aor` (parsing is reflecting the regex corresponding to the selected mode).

## Implementation Details ##
User selection is handled via Javascript_function in the frontend (web/common/form.php).

The backend will update the table `registrant` via standard php functions.
The table has to support  the new filed `registrar_mode` in its schema (opensips PR is uploaded) . 

All given processing in opensips shouldn't  be affected, if you select RFC3261. This routines do reley on a `aor` syntax field, that should hold the correct syntax. To support RFC6140, The opensips routines have to be adopted.

## Open issues ##

It's not perfect yet. Validation of `aor` is defined, but the regex isn't evaluated.
I haven't found a  valid method, to 'preset' the refererid fields based on the default selection in the selectionbox (here: `registrar_tooltip`, `re`). Handling is correct, if user does actively choose a selectionbox option.

Ralf