### PR TITLE
Fix 'System/MI commands' when no box selected

### DIFF
--- a/web/tools/system/mi/lib/functions.inc.php
+++ b/web/tools/system/mi/lib/functions.inc.php
@@ -56,6 +56,8 @@ function show_boxes($boxen,$current_box){
 	echo ('<input type="hidden" name="box_val" class="formInput" method="post" value="">');
 	echo ('<select name="box_list" class="boxSelect" onChange=boxen_select.box_val.value=boxen_select.box_list.value;boxen_select.submit() >');
 
+	if (empty($current_box)) $current_box=key($boxen);
+
 	foreach ( $boxen as $key => $val )
 	if (!empty($val)) {
 		echo '<option value="'.$key.'"' ;


### PR DESCRIPTION
If there is only one box in **System/MI commands** or if we don't select box, this patch fix the issue that `$current_box` is empty. #67 