### PR TITLE
Allow 128 characters for attributes when editing drouting gateways

### DIFF
--- a/web/tools/system/drouting/template/gateways.edit.php
+++ b/web/tools/system/drouting/template/gateways.edit.php
@@ -86,7 +86,7 @@
  </tr>
  <tr>
   <td class="dataRecord"><b><?=$config->gw_attributes["display_name"]?></b></td>
-  <td class="dataRecord"><input type="text" name="attrs" value="<?php echo htmlspecialchars($resultset[0]['attrs']);?>" maxlength="16" class="dataInput"></td>
+  <td class="dataRecord"><input type="text" name="attrs" value="<?php echo htmlspecialchars($resultset[0]['attrs']);?>" maxlength="128" class="dataInput"></td>
  </tr>
 
  <tr>


### PR DESCRIPTION
The control panel allows adding a new dynamic routing gateway with a long attributes value, but limits to 16 characters when trying to modify it. This patch fixes the edit page to allow the same limit of 128, matching the actual database limit.