### PR TITLE
Changed the for loop to a foreach when building the list of mi_connectors

### DIFF
--- a/web/common/cfg_comm.php
+++ b/web/common/cfg_comm.php
@@ -30,11 +30,11 @@ function get_proxys_by_assoc_id($my_assoc_id){
 
 	$mi_connectors=array();
 
-	for ($i=0;$i<count($boxes);$i++){
+	foreach($boxes as $box) {
 
-		if ($boxes[$i]['assoc_id']==$my_assoc_id){
+		if ($box['assoc_id']==$my_assoc_id){
 
-			$mi_connectors[]=$boxes[$i]['mi']['conn'];
+			$mi_connectors[]=$box['mi']['conn'];
 
 		}
 
@@ -51,11 +51,11 @@ function get_all_proxys_by_assoc_id($my_assoc_id){
 
 	$mi_connectors=array();
 
-	for ($i=0;$i<count($boxes);$i++){
+	foreach($boxes as $box) {
 
-		if ($boxes[$i]['assoc_id']==$my_assoc_id){
+		if ($box['assoc_id']==$my_assoc_id){
 
-			$mi_connectors[]=$boxes[$i]['mi']['conn'];
+			$mi_connectors[]=$box['mi']['conn'];
 
 		}
 


### PR DESCRIPTION
The existing for loop was assuming that the user was using array keys sequentially in the $boxes array.

While this would normally be the case, the example code encourages you to skip a key as the example for 'Presence Server' used a commented out key of '1' - the symptom here was that the mi_connectors array was not built correctly as it assumed that the keys in $boxes would always be sequential, starting with 0