### PR TITLE
Added Optional MySql SSL Certificate

### DIFF
--- a/config/db.inc.php
+++ b/config/db.inc.php
@@ -40,6 +40,9 @@ if (!isset($config)) $config = new stdClass();
  //database name
  $config->db_name = "opensips";
 
+ //database certificate
+ $config->db_cert = "";
+
  if (!empty($config->db_port) ) $config->db_host = $config->db_host . ";port=" . $config->db_port;
  
 ?>

--- a/config/tools/admin/list_admins/db.inc.php
+++ b/config/tools/admin/list_admins/db.inc.php
@@ -34,6 +34,9 @@
  
  //database name
  //$config->db_name_list_admin = "opensips";
+
+ //database certificate
+ //$config->db_cert_list_admins = "";
  
  //if ($config->db_port_list_admin != "") $config->db_host_list_admin = $config->db_host_list_admin . ";port=" . $config->db_port_list_admin;
  

--- a/config/tools/system/callcenter/db.inc.php
+++ b/config/tools/system/callcenter/db.inc.php
@@ -36,6 +36,7 @@
 # $custom_config[$module_id][0]['db_pass'] 		= "";
  //database port
 # $custom_config[$module_id][0]['db_port'] 		= "";
- 
+ //database certificate 
+# $custom_config[$module_id][0]['db_cert']      = "";
 
 ?>

--- a/config/tools/system/cdrviewer/db.inc.php
+++ b/config/tools/system/cdrviewer/db.inc.php
@@ -34,6 +34,9 @@
  
  //database name
  //$config->db_name_cdrviewer = "opensips";
+
+ //database certificate
+ //$config->db_cert_cdrviewer = "";
  
  //if ($config->db_port_cdrviewer != "") $config->db_host_cdrviewer = $config->db_host_cdrviewer . ";port=" . $config->db_port_cdrviewer;
  

--- a/config/tools/system/clusterer/db.inc.php
+++ b/config/tools/system/clusterer/db.inc.php
@@ -34,6 +34,9 @@
  
  //database name
  //$config->db_name_clusterer = "opensips";
+
+ //database certificate
+ //$config->db_cert_clusterer = "";
  
  //if ($config->db_port_clusterer != "") $config->db_host_clusterer = $config->db_host_clusterer . ";port=" . $config->db_port_clusterer;
  

--- a/config/tools/system/dialplan/db.inc.php
+++ b/config/tools/system/dialplan/db.inc.php
@@ -34,6 +34,9 @@
  
  //database name
  //$config->db_name_dialplan = "opensips";
+
+ //database certificate
+ //$config->db_cert_dialplan = "";
  
  //if ($config->db_port_dialplan != "") $config->db_host_dialplan = $config->db_host_dialplan . ";port=" . $config->db_port_dialplan;
  

--- a/config/tools/system/dispatcher/db.inc.php
+++ b/config/tools/system/dispatcher/db.inc.php
@@ -35,6 +35,9 @@
  
  //database name
  //$config->db_name_dispatcher = "opensips";
+
+ //database certificate
+ //$config->db_cert_dispatcher = "";
  
  //if ($config->db_port_dispatcher != "") $config->db_host_dispatcher = $config->db_host_dispatcher .";port=" . $config->db_port_dispatcher;
  

--- a/config/tools/system/domains/db.inc.php
+++ b/config/tools/system/domains/db.inc.php
@@ -34,6 +34,9 @@
  
  //database name
  //$config->db_name_domains = "opensips";
+
+ //database certificate
+ //$config->db_cert_domains = "";
  
  //if ($config->db_port_domains != "") $config->db_host_domains = $config->db_host_domains . ";port=" . $config->db_port_domains;
  

--- a/config/tools/system/drouting/db.inc.php
+++ b/config/tools/system/drouting/db.inc.php
@@ -35,6 +35,9 @@
  
  //database name
  //$config->db_name_drouting = "opensips";
+
+ //database certificate
+ //$config->db_cert_drouting = "";
  
  //if ($config->db_port_drouting != "") $config->db_host_drouting = $config->db_host_drouting . ";port=" . $config->db_port_drouting;
  

--- a/config/tools/system/loadbalancer/db.inc.php
+++ b/config/tools/system/loadbalancer/db.inc.php
@@ -34,6 +34,9 @@
  
  //database name
  //$config->db_name_loadbalancer = "opensips";
+
+ //database certificate
+ //$config->db_cert_loadbalancer = "";
  
  //if ($config->db_port_loadbalancer != "") $config->db_host_loadbalancer = $config->db_host_loadbalancer . ";port=" . $config->db_port_loadbalancer;
  

--- a/config/tools/system/permissions/db.inc.php
+++ b/config/tools/system/permissions/db.inc.php
@@ -35,6 +35,9 @@
  
  //database name
  //$config->db_name_permissions = "opensips";
+
+ //database certificate
+ //$config->db_cert_permissions = "";
  
  //if ($config->db_port_permissions != "") $config->db_host_permissions = $config->db_host_permissions . ";port=" . $config->db_port_permissions;
  

--- a/config/tools/system/rtpengine/db.inc.php
+++ b/config/tools/system/rtpengine/db.inc.php
@@ -34,6 +34,9 @@
  
  //database name
  //$config->db_name_rtpengine = "opensips";
+
+ //database certificate
+ //$config->db_cert_rtpengine = "";
  
  //if ($config->db_port_rtpengine != "") $config->db_host_rtpengine = $config->db_host_rtpengine . ";port=" . $config->db_port_rtpengine;
  

--- a/config/tools/system/rtpproxy/db.inc.php
+++ b/config/tools/system/rtpproxy/db.inc.php
@@ -34,6 +34,9 @@
  
  //database name
  //$config->db_name_rtpproxy = "opensips";
+
+ //database certificate
+ //$config->db_cert_rtpproxy = "";
  
  //if ($config->db_port_rtpproxy != "") $config->db_host_rtpproxy = $config->db_host_rtpproxy . ";port=" . $config->db_port_rtpproxy;
  

--- a/config/tools/system/siptrace/db.inc.php
+++ b/config/tools/system/siptrace/db.inc.php
@@ -34,6 +34,9 @@
  
  //database name
  //$config->db_name_siptrace = "opensips_1_4";
+
+ //database certificate
+ //$config->db_cert_siptrace = "";
  
  //if ($config->db_port_siptrace != "") $config->db_host_siptrace = $config->db_host_siptrace . ";port=" . $config->db_port_siptrace;
  

--- a/config/tools/system/smonitor/db.inc.php
+++ b/config/tools/system/smonitor/db.inc.php
@@ -35,6 +35,9 @@
  
  //database name
  //$config->db_name_smonitor = "opensips";
+
+ //database certificate
+ //$config->db_cert_smonitor = "";
  
  //if ($config->db_port_smonitor != "") $config->db_host_smonitor = $config->db_host_smonitor . ";port=" . $config->db_port_smonitor;
  

--- a/config/tools/system/smpp/db.inc.php
+++ b/config/tools/system/smpp/db.inc.php
@@ -36,6 +36,7 @@
 # $custom_config[$module_id][0]['db_pass'] 		= "";
  //database port
 # $custom_config[$module_id][0]['db_port'] 		= "";
- 
+ //database certificate 
+# $custom_config[$module_id][0]['db_cert']      = ""
 
 ?>

--- a/config/tools/system/tls_mgm/db.inc.php
+++ b/config/tools/system/tls_mgm/db.inc.php
@@ -36,6 +36,8 @@
 # $custom_config[$module_id][0]['db_pass'] 		= "";
  //database port
 # $custom_config[$module_id][0]['db_port'] 		= "";
+ //database certificate 
+# $custom_config[$module_id][0]['db_cert']      = ""
  
 
 ?>

--- a/config/tools/system/tviewer/db.inc.php
+++ b/config/tools/system/tviewer/db.inc.php
@@ -36,6 +36,8 @@
 # $custom_config[$module_id][0]['db_pass'] 		= "";
  //database port
 # $custom_config[$module_id][0]['db_port'] 		= "";
+ //database certificate 
+# $custom_config[$module_id][0]['db_cert']      = ""
  
 
 ?>

--- a/config/tools/system/uac_registrant/db.inc.php
+++ b/config/tools/system/uac_registrant/db.inc.php
@@ -36,6 +36,8 @@
 # $custom_config[$module_id][0]['db_pass'] 		= "";
  //database port
 # $custom_config[$module_id][0]['db_port'] 		= "";
+ //database certificate 
+# $custom_config[$module_id][0]['db_cert']      = ""
  
 
 ?>

--- a/config/tools/users/acl_management/db.inc.php
+++ b/config/tools/users/acl_management/db.inc.php
@@ -34,6 +34,9 @@
  
  //database name
  //$config->db_name_acl_management = "opensips";
+
+ //database certificate
+ //$config->db_cert_acl_management = "";
  
  //if ($config->db_port_acl_management != "") $config->db_host_acl_management = $config->db_host_acl_management . ";port=" . $config->db_port_acl_management;
  

--- a/config/tools/users/alias_management/db.inc.php
+++ b/config/tools/users/alias_management/db.inc.php
@@ -34,6 +34,9 @@
  
  //database name
  //$config->db_name_alias_management = "opensips";
+
+ //database certificate
+ //$config->db_cert_alias_management = "";
  
  //if ($config->db_port_alias_management != "") $config->db_host_alias_management = $config->db_host_alias_management . ";port=" . $config->db_port_alias_management;
  

--- a/config/tools/users/user_management/db.inc.php
+++ b/config/tools/users/user_management/db.inc.php
@@ -34,6 +34,9 @@
  
  //database name
  //$config->db_name_user_management = "opensips";
+
+ //database certificate
+ //$config->db_cert_user_management = "";
  
  //if ($config->db_port_user_management != "") $config->db_host_user_management = $config->db_host_user_management . ";port=" . $config->db_port_user_management;
  

--- a/web/db_connect.php
+++ b/web/db_connect.php
@@ -26,8 +26,13 @@ require_once("../config/db.inc.php");
 global $config;
 $dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 
+$options = array();
+if ($config->db_cert) {
+	$options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+}
+
 try {
-	$link = new PDO($dsn, $config->db_user, $config->db_pass);
+	$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 } catch (PDOException $e) {
 	error_log(print_r("Failed to connect to: ".$dsn, true));
 	print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/admin/list_admins/lib/db_connect.php
+++ b/web/tools/admin/list_admins/lib/db_connect.php
@@ -32,9 +32,17 @@ require_once("../../../../config/db.inc.php");
                 $config->db_pass = $config->db_pass_list_admins;
                 $config->db_name = $config->db_name_list_admins;
         }
+
+        $options = array();
+        if (isset($config->db_cert_list_admins))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_list_admins;
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 	$dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 	try {
-		$link = new PDO($dsn, $config->db_user, $config->db_pass);
+		$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 	} catch (PDOException $e) {
 		error_log(print_r("Failed to connect to: ".$dsn, true));
 		print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/callcenter/lib/db_connect.php
+++ b/web/tools/system/callcenter/lib/db_connect.php
@@ -10,11 +10,18 @@ require_once("../../../../config/tools/".$branch."/".$module_id."/db.inc.php");
                 $config->db_name = $custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['db_name'];
 		if (isset($config->db_port) && is_int((int)$config->db_port) && 1 < $config->db_port && $config->db_port < 65535) 
 			$config->db_host = $config->db_host.";port=".$config->db_port;
+		}
+		
+		$options = array();
+        if (isset($custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['db_cert']))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['db_cert'];
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
         }
 	
 		$dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 		try {
-			$link = new PDO($dsn, $config->db_user, $config->db_pass);
+			$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 		} catch (PDOException $e) {
 			error_log(print_r("Failed to connect to: ".$dsn, true));
 			print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/cdrviewer/lib/db_connect.php
+++ b/web/tools/system/cdrviewer/lib/db_connect.php
@@ -32,9 +32,17 @@ require_once("../../../../config/db.inc.php");
                 $config->db_pass = $config->db_pass_cdrviewer;
                 $config->db_name = $config->db_name_cdrviewer;
         }
+
+        $options = array();
+        if (isset($config->db_cert_cdrviewer))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_cdrviewer;
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
         $dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
         try {
-               $link = new PDO($dsn, $config->db_user, $config->db_pass);
+               $link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
         } catch (PDOException $e) {
                error_log(print_r("Failed to connect to: ".$dsn, true));
                print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/clusterer/lib/db_connect.php
+++ b/web/tools/system/clusterer/lib/db_connect.php
@@ -32,9 +32,17 @@ require_once("../../../../config/db.inc.php");
                 $config->db_pass = $config->db_pass_clusterer;
                 $config->db_name = $config->db_name_clusterer;
         }
+
+        $options = array();
+        if (isset($config->db_cert_clusterer))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_clusterer;
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
         $dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
         try {
-               $link = new PDO($dsn, $config->db_user, $config->db_pass);
+               $link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
         } catch (PDOException $e) {
                error_log(print_r("Failed to connect to: ".$dsn, true));
                print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/dialplan/lib/db_connect.php
+++ b/web/tools/system/dialplan/lib/db_connect.php
@@ -32,9 +32,16 @@ if (isset($config->db_host_dialplan) && isset($config->db_user_dialplan) && isse
 	$config->db_name = $config->db_name_dialplan;
 }
 
+$options = array();
+        if (isset($config->db_cert_dialplan))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_dialplan;
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 $dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 try {
-	$link = new PDO($dsn, $config->db_user, $config->db_pass);
+	$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 } catch (PDOException $e) {
 	error_log(print_r("Failed to connect to: ".$dsn, true));
 	print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/dispatcher/lib/db_connect.php
+++ b/web/tools/system/dispatcher/lib/db_connect.php
@@ -32,9 +32,17 @@ require_once("../../../../config/db.inc.php");
                 $config->db_pass = $config->db_pass_dispatcher;
                 $config->db_name = $config->db_name_dispatcher;
         }
+
+        $options = array();
+        if (isset($config->db_cert_dispatcher))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_dispatcher;
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 	$dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 	try {
-		$link = new PDO($dsn, $config->db_user, $config->db_pass);
+		$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 	} catch (PDOException $e) {
 		error_log(print_r("Failed to connect to: ".$dsn, true));
 		print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/domains/lib/db_connect.php
+++ b/web/tools/system/domains/lib/db_connect.php
@@ -32,9 +32,17 @@ require_once("../../../../config/db.inc.php");
                 $config->db_pass = $config->db_pass_domains;
                 $config->db_name = $config->db_name_domains;
         }
+
+        $options = array();
+        if (isset($config->db_cert_domains))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_domains;
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 	$dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 	try {
-		$link = new PDO($dsn, $config->db_user, $config->db_pass);
+		$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 	} catch (PDOException $e) {
 		error_log(print_r("Failed to connect to: ".$dsn, true));
 		print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/drouting/lib/db_connect.php
+++ b/web/tools/system/drouting/lib/db_connect.php
@@ -31,9 +31,17 @@ require_once("../../../../config/db.inc.php");
                 $config->db_pass = $config->db_pass_drouting;
                 $config->db_name = $config->db_name_drouting;
         }
+
+        $options = array();
+        if (isset($config->db_cert_drouting))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_drouting;
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 	$dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 	try {
-		$link = new PDO($dsn, $config->db_user, $config->db_pass);
+		$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 	} catch (PDOException $e) {
 		error_log(print_r("Failed to connect to: ".$dsn, true));
 		print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/loadbalancer/lib/db_connect.php
+++ b/web/tools/system/loadbalancer/lib/db_connect.php
@@ -32,9 +32,17 @@ require_once("../../../../config/db.inc.php");
                 $config->db_pass = $config->db_pass_loadbalancer;
                 $config->db_name = $config->db_name_loadbalancer;
         }
+
+        $options = array();
+        if (isset($config->db_cert_loadbalancer))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_loadbalancer;
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 	$dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 	try {
-		$link = new PDO($dsn, $config->db_user, $config->db_pass);
+		$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 	} catch (PDOException $e) {
 		error_log(print_r("Failed to connect to: ".$dsn, true));
 		print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/permissions/lib/db_connect.php
+++ b/web/tools/system/permissions/lib/db_connect.php
@@ -32,9 +32,16 @@ if (isset($config->db_host_permissions) && isset($config->db_user_permissions) &
 	$config->db_name = $config->db_name_permissions;
 }
 
+$options = array();
+        if (isset($config->db_cert_permissions))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_permissions;
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 $dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 try {
-	$link = new PDO($dsn, $config->db_user, $config->db_pass);
+	$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 } catch (PDOException $e) {
 	error_log(print_r("Failed to connect to: ".$dsn, true));
 	print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/rtpengine/lib/db_connect.php
+++ b/web/tools/system/rtpengine/lib/db_connect.php
@@ -32,9 +32,16 @@ if (isset($config->db_host_rtpengine) && isset($config->db_user_rtpengine) && is
 	$config->db_name = $config->db_name_rtpengine;
 }
 
+$options = array();
+        if (isset($config->db_cert_rtpengine))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_rtpengine;
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 $dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 try {
-	$link = new PDO($dsn, $config->db_user, $config->db_pass);
+	$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 } catch (PDOException $e) {
 	error_log(print_r("Failed to connect to: ".$dsn, true));
 	print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/rtpproxy/lib/db_connect.php
+++ b/web/tools/system/rtpproxy/lib/db_connect.php
@@ -32,9 +32,16 @@ if (isset($config->db_host_rtpproxy) && isset($config->db_user_rtpproxy) && isse
 	$config->db_name = $config->db_name_rtpproxy;
 }
 
+$options = array();
+        if (isset($config->db_cert_rtpproxy))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_rtpproxy;
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 $dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 try {
-	$link = new PDO($dsn, $config->db_user, $config->db_pass);
+	$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 } catch (PDOException $e) {
 	error_log(print_r("Failed to connect to: ".$dsn, true));
 	print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/siptrace/lib/db_connect.php
+++ b/web/tools/system/siptrace/lib/db_connect.php
@@ -32,9 +32,17 @@ require_once("../../../../config/db.inc.php");
                 $config->db_pass = $config->db_pass_siptrace;
                 $config->db_name = $config->db_name_siptrace;
         }
+
+        $options = array();
+        if (isset($config->db_cert_siptrace))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_siptrace;
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 	$dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 	try {
-		$link = new PDO($dsn, $config->db_user, $config->db_pass);
+		$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 	} catch (PDOException $e) {
 		error_log(print_r("Failed to connect to: ".$dsn, true));
 		print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/smonitor/lib/db_connect.php
+++ b/web/tools/system/smonitor/lib/db_connect.php
@@ -32,9 +32,16 @@ if (isset($config->db_host_smonitor) && isset($config->db_user_smonitor) && isse
 	$config->db_name = $config->db_name_smonitor;
 }
 
+$options = array();
+        if (isset($config->db_cert_smonitor))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_smonitor;
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 $dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 try {
-	$link = new PDO($dsn, $config->db_user, $config->db_pass);
+	$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 } catch (PDOException $e) {
 	error_log(print_r("Failed to connect to: ".$dsn, true));
 	print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/smpp/lib/db_connect.php
+++ b/web/tools/system/smpp/lib/db_connect.php
@@ -14,9 +14,16 @@ if (isset($custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['
 		$config->db_host = $config->db_host.";port=".$config->db_port;
 }
 
+$options = array();
+        if (isset($custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['db_cert']))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['db_cert'];
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 $dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 try {
-	$link = new PDO($dsn, $config->db_user, $config->db_pass);
+	$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 } catch (PDOException $e) {
 	error_log(print_r("Failed to connect to: ".$dsn, true));
 	print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/tls_mgm/lib/db_connect.php
+++ b/web/tools/system/tls_mgm/lib/db_connect.php
@@ -14,9 +14,16 @@ if (isset($custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['
 		$config->db_host = $config->db_host.";port=".$config->db_port;
 }
 
+$options = array();
+        if (isset($custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['db_cert']))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['db_cert'];
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 $dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 try {
-	$link = new PDO($dsn, $config->db_user, $config->db_pass);
+	$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 } catch (PDOException $e) {
 	error_log(print_r("Failed to connect to: ".$dsn, true));
 	print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/tviewer/lib/db_connect.php
+++ b/web/tools/system/tviewer/lib/db_connect.php
@@ -14,9 +14,16 @@ if (isset($custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['
 		$config->db_host = $config->db_host.";port=".$config->db_port;
 }
 
+$options = array();
+        if (isset($custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['db_cert']))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['db_cert'];
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 $dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 try {
-	$link = new PDO($dsn, $config->db_user, $config->db_pass);
+	$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 } catch (PDOException $e) {
 	error_log(print_r("Failed to connect to: ".$dsn, true));
 	print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/system/uac_registrant/lib/db_connect.php
+++ b/web/tools/system/uac_registrant/lib/db_connect.php
@@ -14,9 +14,16 @@ if (isset($custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['
 		$config->db_host = $config->db_host.";port=".$config->db_port;
 }
 
+$options = array();
+        if (isset($custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['db_cert']))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['db_cert'];
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 $dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 try {
-	$link = new PDO($dsn, $config->db_user, $config->db_pass);
+	$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 } catch (PDOException $e) {
 	error_log(print_r("Failed to connect to: ".$dsn, true));
 	print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/users/acl_management/lib/db_connect.php
+++ b/web/tools/users/acl_management/lib/db_connect.php
@@ -33,9 +33,17 @@ require_once("../../../../config/db.inc.php");
                 $config->db_pass = $config->db_pass_acl_management;
                 $config->db_name = $config->db_name_acl_management;
         }
+
+        $options = array();
+        if (isset($config->db_cert_acl_management))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_acl_management;
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 	$dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 	try {
-		$link = new PDO($dsn, $config->db_user, $config->db_pass);
+		$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 	} catch (PDOException $e) {
 		error_log(print_r("Failed to connect to: ".$dsn, true));
 		print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/users/alias_management/lib/db_connect.php
+++ b/web/tools/users/alias_management/lib/db_connect.php
@@ -33,9 +33,17 @@ require_once("../../../../config/db.inc.php");
                 $config->db_pass = $config->db_pass_alias_management;
                 $config->db_name = $config->db_name_alias_management;
         }
+
+        $options = array();
+        if (isset($config->db_cert_alias_management))
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_alias_management;
+        else if ($config->db_cert) {
+                $options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+        }
+
 	$dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 	try {
-		$link = new PDO($dsn, $config->db_user, $config->db_pass);
+		$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 	} catch (PDOException $e) {
 		error_log(print_r("Failed to connect to: ".$dsn, true));
 		print "Error!: " . $e->getMessage() . "<br/>";

--- a/web/tools/users/user_management/lib/db_connect.php
+++ b/web/tools/users/user_management/lib/db_connect.php
@@ -32,9 +32,17 @@ require_once("../../../../config/db.inc.php");
 		$config->db_pass = $config->db_pass_user_management;
 		$config->db_name = $config->db_name_user_management;
 	}
+
+	$options = array();
+	if (isset($config->db_cert_user_management))
+			$options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert_user_management;
+	else if ($config->db_cert) {
+			$options[PDO::MYSQL_ATTR_SSL_CA] = $config->db_cert;
+	}
+
 	$dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
 	try {
-		$link = new PDO($dsn, $config->db_user, $config->db_pass);
+		$link = new PDO($dsn, $config->db_user, $config->db_pass, $options);
 	} catch (PDOException $e) {
 		error_log(print_r("Failed to connect to: ".$dsn, true));
 		print "Error!: " . $e->getMessage() . "<br/>";


### PR DESCRIPTION
I added a new parameter to the db_inc files called `db_cert` that references a path to a certificate file that will be used to do TLS security for the MySql server. I then also added the `PDO::MYSQL_ATTR_SSL_CA` option to all of the db_connect files to use this parameter.