### PR TITLE
Fixing number of parameters inserting user record.

### DIFF
--- a/web/tools/users/user_management/user_management.php
+++ b/web/tools/users/user_management/user_management.php
@@ -271,7 +271,7 @@ if ($action=="add_verify")
 		foreach ( $config->subs_extra as $key => $value )
 			if (isset($_POST['extra_'.$key]) && $_POST['extra_'.$key]!='')
 				$sql .= ','.$key;
-		$sql .= ') VALUES (?, ?, ?, ?, ? ';
+		$sql .= ') VALUES (?, ?, ?, ? ';
 		$sql_vals = array($uname,$domain,$passwd,$ha1);
 		foreach ( $config->subs_extra as $key => $value )
 			if (isset($_POST['extra_'.$key]) && $_POST['extra_'.$key]!='') {


### PR DESCRIPTION
Description:
The number of parameters and tokens did not match. It had one extra token.

Error:
PHP Warning:  PDOStatement::execute(): SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens in /var/www/html/opensips-cp/web/tools/users/user_management/user_management.php on line 287, referer: http://192.168.2.46/opensips-cp/web/tools/users/user_management/user_management.php?action=add