### PR TITLE
Add grouping for settings parameters (#133)

### DIFF
--- a/web/style_tools.css
+++ b/web/style_tools.css
@@ -179,6 +179,14 @@ a.menuItemSelect:hover {
 	color: #1cbe9a;
 }
 
+.sectionTitle {
+	text-align: left;
+	font-weight: bold;
+	font-size: 17px;
+	padding-bottom: 17px;
+	padding-left: 10px;
+	color: #1cbe9a;
+}
 
 .listTitle {
 	text-align: left;

--- a/web/tools/admin/admin_config/template/admin_config.edit_tools.php
+++ b/web/tools/admin/admin_config/template/admin_config.edit_tools.php
@@ -72,6 +72,9 @@ $permissions=array();
 					form_generate_select($params['name'], $current_tip, $module, 10,  get_value( $module, $box_id), array_values($params['options']), array_keys($params['options']));
 				else form_generate_select($params['name'], $current_tip, $module, 10,  get_value( $module, $box_id), array_values($params['options']));
 				break;
+			case "title":
+					print '<tr> <td class=\'sectionTitle\'><b>'.$params['title'].'</b></td></tr>';
+				break;
 			default:
 				form_generate_input_text($params['name'], $current_tip, $module, $opt, get_value($module, $box_id), 10, $params['validation_regex']);
 		}


### PR DESCRIPTION
Add option to group parameters in the settings tab, with the following syntax:
	"title0" => array(
		"type" => "title",
		"title" => "TITLE NAME"
	)
This should be inserted in the params.php file of a tool in the place where you want the title to appear.
The next title should be inserted as "title1" instead of "title0" etc.