### PR TITLE
Remove old config files from tools migrated to db settings engine

### DIFF
--- a/web/common/cfg_comm.php
+++ b/web/common/cfg_comm.php
@@ -143,7 +143,7 @@ function get_group() {
 
 function display_settings_button($box_id=null) {
 	if (file_exists("params.php") && $_SESSION['permission'] == 'Admin') {  
-		require_once("params.php");
+		require("params.php");
 		if (!is_null($config))
 			if(is_null($box_id))
 				echo("

--- a/web/tools/system/dialog/index.php
+++ b/web/tools/system/dialog/index.php
@@ -20,7 +20,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
- require("../../../../config/tools/system/dialog/local.inc.php");
  include("../../../common/cfg_comm.php");
  require("lib/functions.inc.php");
  session_start();

--- a/web/tools/system/dialog/lib/functions.inc.php
+++ b/web/tools/system/dialog/lib/functions.inc.php
@@ -20,7 +20,7 @@
 * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 function print_profile() {
-require ("../../../../config/tools/system/dialog/local.inc.php");
+	session_load();
 	global $config;
 
 	$mi_connectors=get_proxys_by_assoc_id(get_value('talk_to_this_assoc_id'));

--- a/web/tools/system/dialog/profile.php
+++ b/web/tools/system/dialog/profile.php
@@ -20,10 +20,10 @@
 * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
+require("../../../common/cfg_comm.php");
 require("template/header.php");
 require("lib/".$page_id.".main.js");
 require ("../../../common/mi_comm.php");
-require("../../../common/cfg_comm.php");
 
 $current_page="current_page_dialog";
 

--- a/web/tools/system/dialog/template/header.php
+++ b/web/tools/system/dialog/template/header.php
@@ -20,15 +20,17 @@
 * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
+
  require_once("../../../../config/session.inc.php");
- require_once("../../../../config/tools/system/dialog/local.inc.php");
  require_once("lib/functions.inc.php");
  require_once("../../../../config/tools/system/dialog/menu.inc.php");
+ 
  $page_name = basename($_SERVER['SCRIPT_NAME']);
  $page_id = substr($page_name, 0, strlen($page_name) - 4);
  $_SESSION['current_tool'] = 'dialog';
  $_SESSION['current_group'] = get_group();
  $no_result = "No Data Found.";
+ session_load();
 ?>
 
 <html>

--- a/web/tools/system/dialplan/apply_changes.php
+++ b/web/tools/system/dialplan/apply_changes.php
@@ -22,9 +22,9 @@
 
 
 require_once("../../../../config/session.inc.php");
-require("../../../../config/tools/system/dialplan/local.inc.php");
 require("../../../common/mi_comm.php");
 require("../../../common/cfg_comm.php");
+session_load();
 
 $command="dp_reload";
 

--- a/web/tools/system/dialplan/template/header.php
+++ b/web/tools/system/dialplan/template/header.php
@@ -23,13 +23,13 @@
 require_once("../../../../config/session.inc.php");
 require_once("../../../../config/tools/system/dialplan/db.inc.php");
 require_once("../../../../config/db.inc.php");
-require_once("../../../../config/tools/system/dialplan/local.inc.php");
 
 $page_name = basename($_SERVER['SCRIPT_NAME']);
 $page_id = substr($page_name, 0, strlen($page_name) - 4);
 $_SESSION['current_tool'] = 'dialplan';
 $_SESSION['current_group'] = get_group();
 $no_result = "No Data Found.";
+session_load();
 ?>
 
 <html>

--- a/web/tools/system/drouting/apply_changes.php
+++ b/web/tools/system/drouting/apply_changes.php
@@ -22,9 +22,9 @@
 
 
 require_once("../../../../config/session.inc.php");
-require("../../../../config/tools/system/drouting/local.inc.php");
 require("../../../common/mi_comm.php");
 require("../../../common/cfg_comm.php");
+session_load();
 
 $command="dr_reload";
 if (isset($config->routing_partition) && $config->routing_partition != "")

--- a/web/tools/system/drouting/template/header.php
+++ b/web/tools/system/drouting/template/header.php
@@ -20,18 +20,18 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-
  require_once("../../../../config/session.inc.php");
  require_once("../../../../config/tools/system/drouting/db.inc.php");
  require_once("../../../../config/db.inc.php");
- require_once("../../../../config/tools/system//drouting/menu.inc.php");
- require_once("../../../../config/tools/system/drouting/local.inc.php");
- 
+ require_once("../../../../config/tools/system/drouting/menu.inc.php");
+
  $page_name = basename($_SERVER['SCRIPT_NAME']);
  $page_id = substr($page_name, 0, strlen($page_name) - 4);
  $_SESSION['current_tool'] = 'drouting';
  $_SESSION['current_group'] = get_group();
- $no_result = "No Data Found.";
+ $no_result = "No Data Found."; 
+ session_load();
+ 
 ?>
 
 <html>

--- a/web/tools/system/loadbalancer/apply_changes.php
+++ b/web/tools/system/loadbalancer/apply_changes.php
@@ -24,9 +24,9 @@
 <?php
 
 require_once("../../../../config/session.inc.php");
-require("../../../../config/tools/system/loadbalancer/local.inc.php");
 require("../../../common/mi_comm.php");
 require("../../../common/cfg_comm.php");
+session_load();
 
 $command="lb_reload";
 

--- a/web/tools/system/loadbalancer/loadbalancer.php
+++ b/web/tools/system/loadbalancer/loadbalancer.php
@@ -24,7 +24,6 @@ require ("../../../common/cfg_comm.php");
 require("template/header.php");
 require("lib/".$page_id.".main.js");
 require ("../../../common/mi_comm.php");
-require ("../../../../config/tools/system/loadbalancer/local.inc.php");
 
 $table=$config->table_lb;
 $current_page="current_page_lb";

--- a/web/tools/system/loadbalancer/template/header.php
+++ b/web/tools/system/loadbalancer/template/header.php
@@ -23,13 +23,13 @@
 require_once("../../../../config/session.inc.php");
 require_once("../../../../config/db.inc.php");
 require_once("../../../../config/tools/system/loadbalancer/db.inc.php");
-require_once("../../../../config/tools/system/loadbalancer/local.inc.php");
 
 $page_name = basename($_SERVER['SCRIPT_NAME']);
 $page_id = substr($page_name, 0, strlen($page_name) - 4);
 $_SESSION['current_tool'] = 'loadbalancer';
 $_SESSION['current_group'] = get_group();
 $no_result = "No Data Found.";
+session_load();
 ?>
 
 <html>

--- a/web/tools/system/permissions/apply_changes.php
+++ b/web/tools/system/permissions/apply_changes.php
@@ -22,9 +22,9 @@
 
 
 require_once("../../../../config/session.inc.php");
-require("../../../../config/tools/system/permissions/local.inc.php");
 require("../../../common/mi_comm.php");
 require("../../../common/cfg_comm.php");
+session_load();
 
 $command="address_reload";
 

--- a/web/tools/system/permissions/template/header.php
+++ b/web/tools/system/permissions/template/header.php
@@ -23,13 +23,13 @@
 require_once("../../../../config/session.inc.php");
 require_once("../../../../config/tools/system/permissions/db.inc.php");
 require_once("../../../../config/db.inc.php");
-require_once("../../../../config/tools/system/permissions/local.inc.php");
 
 $page_name = basename($_SERVER['SCRIPT_NAME']);
 $page_id = substr($page_name, 0, strlen($page_name) - 4);
 $_SESSION['current_tool'] = 'permissions';
 $_SESSION['current_group'] = get_group();
 $no_result = "No Data Found.";
+session_load();
 ?>
 
 <html>

--- a/web/tools/system/rtpengine/apply_changes.php
+++ b/web/tools/system/rtpengine/apply_changes.php
@@ -26,7 +26,7 @@
 require_once("../../../../config/session.inc.php");
 require("../../../common/mi_comm.php");
 require("../../../common/cfg_comm.php");
-require("../../../../config/tools/system/rtpengine/local.inc.php");
+session_load();
 
 $command="rtpengine_reload";
 

--- a/web/tools/system/rtpengine/index.php
+++ b/web/tools/system/rtpengine/index.php
@@ -22,7 +22,6 @@
 
  require("../../../../config/tools/system/rtpengine/db.inc.php");
  require("../../../../config/db.inc.php");
- require("../../../../config/tools/system/rtpengine/local.inc.php");
  require("../../../common/cfg_comm.php");
 
  session_start();

--- a/web/tools/system/rtpengine/template/header.php
+++ b/web/tools/system/rtpengine/template/header.php
@@ -22,13 +22,13 @@
 
  require_once("../../../../config/session.inc.php");
  require_once("../../../../config/tools/system/rtpengine/db.inc.php");
- require_once("../../../../config/tools/system/rtpengine/local.inc.php");
 
  $page_name = basename($_SERVER['SCRIPT_NAME']);
  $page_id = substr($page_name, 0, strlen($page_name) - 4);
  $_SESSION['current_tool'] = 'rtpengine';
 $_SESSION['current_group'] = get_group();
  $no_result = "No Data Found.";
+ session_load();
 ?>
 
 <html>

--- a/web/tools/system/rtpproxy/apply_changes.php
+++ b/web/tools/system/rtpproxy/apply_changes.php
@@ -26,7 +26,7 @@
 require_once("../../../../config/session.inc.php");
 require("../../../common/mi_comm.php");
 require("../../../common/cfg_comm.php");
-require("../../../../config/tools/system/rtpproxy/local.inc.php");
+session_load();
 
 $command="rtpproxy_reload";
 

--- a/web/tools/system/rtpproxy/index.php
+++ b/web/tools/system/rtpproxy/index.php
@@ -22,7 +22,6 @@
 
  require("../../../../config/tools/system/rtpproxy/db.inc.php");
  require("../../../../config/db.inc.php");
- require("../../../../config/tools/system/rtpproxy/local.inc.php");
  require("../../../common/cfg_comm.php");
 
  session_start();

--- a/web/tools/system/rtpproxy/template/header.php
+++ b/web/tools/system/rtpproxy/template/header.php
@@ -22,13 +22,13 @@
 
  require_once("../../../../config/session.inc.php");
  require_once("../../../../config/tools/system/rtpproxy/db.inc.php");
- require_once("../../../../config/tools/system/rtpproxy/local.inc.php");
 
  $page_name = basename($_SERVER['SCRIPT_NAME']);
  $page_id = substr($page_name, 0, strlen($page_name) - 4);
  $_SESSION['current_tool'] = 'rtpproxy';
 $_SESSION['current_group'] = get_group();
  $no_result = "No Data Found.";
+ session_load();
 ?>
 
 <html>

--- a/web/tools/system/smonitor/charts.php
+++ b/web/tools/system/smonitor/charts.php
@@ -20,8 +20,8 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+ require("../../../common/cfg_comm.php");
  require("../../../common/mi_comm.php");
- require("../../../../config/tools/system/smonitor/local.inc.php"); 
  require("../../../../config/tools/system/smonitor/db.inc.php"); 
  require("../../../../config/db.inc.php"); 
  require("lib/functions.inc.php");
@@ -29,6 +29,7 @@
  session_start();  
  require("template/header.php");
  include("lib/db_connect.php"); 
+ session_load($_SESSION['box_id']);
  
  $box_id=get_box_id($current_box); 
  $table=$config->table_monitoring;

--- a/web/tools/system/smonitor/get_data.php
+++ b/web/tools/system/smonitor/get_data.php
@@ -2,7 +2,6 @@
 	session_start();
     require_once("../../../../config/tools/system/smonitor/db.inc.php");
     require_once("../../../../config/db.inc.php");
-	require("../../../../config/tools/system/smonitor/local.inc.php");
     
     $dsn = $config->db_driver . ':host=' . $config->db_host . ';dbname='. $config->db_name;
     try {
@@ -19,6 +18,7 @@
     $box = $_GET['box'];
     $normal = $_GET['normal'];
     $sampling_time = $_SESSION['sampling_time'];
+    $table_monitoring = $_SESSION['tmonitoring'];
     $vals ="";
     $vals.="date,value";
     $chart_size = $_SESSION['chart_size'];
@@ -26,7 +26,7 @@
         $chart_size = $_SESSION['chart_history'];
     }
 
-    $sql = "SELECT * FROM ".$config->table_monitoring." WHERE name = ? AND box_id = ? AND time > ? ORDER BY time DESC";
+    $sql = "SELECT * FROM ".$table_monitoring." WHERE name = ? AND box_id = ? AND time > ? ORDER BY time DESC";
     $stm = $link->prepare($sql);
 	$stm->execute(array($fstat, $box, time() - $chart_size * 3600));
     $row = $stm->fetchAll(PDO::FETCH_ASSOC);

--- a/web/tools/system/smonitor/index.php
+++ b/web/tools/system/smonitor/index.php
@@ -23,7 +23,6 @@
  
  require("../../../../config/tools/system/smonitor/db.inc.php");
  require("../../../../config/db.inc.php");
- require("../../../../config/tools/system/smonitor/local.inc.php");
  require("../../../common/mi_comm.php"); 
  require("../../../common/cfg_comm.php"); 
  require("lib/functions.inc.php");

--- a/web/tools/system/smonitor/lib/functions.inc.php
+++ b/web/tools/system/smonitor/lib/functions.inc.php
@@ -252,7 +252,6 @@ function show_graph($stat,$box_id){
 	$var = $stat;
 	require("../../../../config/tools/system/smonitor/db.inc.php");
 	require("../../../../config/db.inc.php");
-	require("../../../../config/tools/system/smonitor/local.inc.php");
 	require("db_connect.php");
 
 	$_SESSION['full_stat'] = $var;
@@ -262,6 +261,7 @@ function show_graph($stat,$box_id){
 	$_SESSION['chart_size'] = get_value("chart_size", $box_id);
 	$_SESSION['box_id_graph'] = $box_id;
 	$_SESSION['chart_history'] = get_value("chart_history", $box_id);
+	$_SESSION['tmonitoring'] = get_value("table_monitoring", $box_id);
 
 	$normal_chart = false ;
 	if (in_array($var , $gauge_arr ))  $normal_chart = true ;
@@ -269,7 +269,7 @@ function show_graph($stat,$box_id){
 	if ($normal_chart) {
 		$_SESSION['normal'] = 1;
 	}
-	
+
 	require("lib/d3js.php");
 
 }

--- a/web/tools/system/smonitor/rt_stats.php
+++ b/web/tools/system/smonitor/rt_stats.php
@@ -24,7 +24,6 @@
  
  require("../../../common/cfg_comm.php");
  require("../../../common/mi_comm.php");
- require("../../../../config/tools/system/smonitor/local.inc.php");
  require("../../../../config/tools/system/smonitor/db.inc.php");
  require("../../../../config/db.inc.php");
  require("lib/functions.inc.php");

--- a/web/tools/system/smonitor/template/header.php
+++ b/web/tools/system/smonitor/template/header.php
@@ -25,13 +25,13 @@
  require_once("../../../../config/db.inc.php");
  require_once("../../../../config/tools/system/smonitor/db.inc.php");
  require_once("../../../../config/tools/system/smonitor/menu.inc.php");
- require_once("../../../../config/tools/system/smonitor/local.inc.php");
  require_once("lib/functions.inc.php");
  $page_name = basename($_SERVER['SCRIPT_NAME']);
  $page_id = substr($page_name, 0, strlen($page_name) - 4);
  $_SESSION['current_tool'] = 'smonitor';
  $_SESSION['current_group'] = get_group();
  $no_result = "No Data Found.";
+ session_load($_SESSION['box_id']);
 ?>
 
 <html>

--- a/web/tools/users/acl_management/acl_management.php
+++ b/web/tools/users/acl_management/acl_management.php
@@ -24,7 +24,6 @@ require("../../../common/cfg_comm.php");
 require("template/header.php");
 require("lib/".$page_id.".main.js");
 require("../../../../config/globals.php");
-require("../../../../config/tools/users/acl_management/local.inc.php");
 
 $table=$config->table_acls;
 $errors='';

--- a/web/tools/users/acl_management/lib/acl_management.add.validate.php
+++ b/web/tools/users/acl_management/lib/acl_management.add.validate.php
@@ -21,8 +21,8 @@
  */
 
 require_once("../../../../../config/db.inc.php");
-require("../../../../../config/tools/users/acl_management/local.inc.php");
 require_once("../../../../../config/tools/users/acl_management/db.inc.php");
+session_load();
 
         global $config;
         if (isset($config->db_host_acl_management) && isset($config->db_user_acl_management) && isset($config->db_name_acl_management) ) {

--- a/web/tools/users/acl_management/lib/functions.inc.php
+++ b/web/tools/users/acl_management/lib/functions.inc.php
@@ -70,7 +70,7 @@ function print_domains($type,$value)
 }
 
 function print_groups($type,$value,$has_any){
-	require("../../../../config/tools/users/acl_management/local.inc.php");
+	session_load();
 	?>
 	<select name=<?=$type?> id=<?=$type?> size="1" style="width: 190px" class="dataSelect">
 	<?php

--- a/web/tools/users/acl_management/template/acl_management.main.php
+++ b/web/tools/users/acl_management/template/acl_management.main.php
@@ -108,7 +108,7 @@ echo('<th class="listTitle">Edit</th>
 
 <?php
         require("../../../../config/db.inc.php");
-        require("../../../../config/tools/users/acl_management/local.inc.php");
+        session_load();
 
 	$sql_command="from ".$table.$sql_search;
 	$stm = $link->prepare("select count(*) ".$sql_command);

--- a/web/tools/users/acl_management/template/header.php
+++ b/web/tools/users/acl_management/template/header.php
@@ -23,7 +23,6 @@
 require_once("../../../../config/session.inc.php");
 require_once("../../../../config/tools/users/acl_management/db.inc.php");
 require_once("../../../../config/db.inc.php");
-require_once("../../../../config/tools/users/acl_management/local.inc.php");
 require_once("lib/functions.inc.php");
 
 $page_name = basename($_SERVER['SCRIPT_NAME']);
@@ -31,6 +30,7 @@ $page_id = substr($page_name, 0, strlen($page_name) - 4);
 $_SESSION['current_tool'] = 'acl_management';
 $_SESSION['current_group'] = get_group();
 $no_result = "No Data Found.";
+session_load();
 ?>
 
 <html>

--- a/web/tools/users/alias_management/alias_management.php
+++ b/web/tools/users/alias_management/alias_management.php
@@ -24,7 +24,6 @@ require("../../../common/cfg_comm.php");
 require("template/header.php");
 require("lib/".$page_id.".main.js");
 require("../../../../config/globals.php");
-require("../../../../config/tools/users/alias_management/local.inc.php");
 
 foreach ($config->table_aliases as $key=>$value) {
 	$options[]=array("label"=>$key,"value"=>$value);

--- a/web/tools/users/alias_management/lib/alias_management.add.validate.php
+++ b/web/tools/users/alias_management/lib/alias_management.add.validate.php
@@ -21,10 +21,10 @@
  */
 
 
-require("../../../../../config/tools/users/alias_management/local.inc.php");
 
 require_once("../../../../../config/tools/users/alias_management/db.inc.php");
 require_once("../../../../../config/db.inc.php");
+session_load();
 
 global $config;
 if (isset($config->db_host_alias_management) && isset($config->db_user_alias_management) && isset($config->db_name_alias_management) ) {

--- a/web/tools/users/alias_management/template/header.php
+++ b/web/tools/users/alias_management/template/header.php
@@ -23,7 +23,6 @@
 require_once("../../../../config/session.inc.php");
 require_once("../../../../config/tools/users/alias_management/db.inc.php");
 require_once("../../../../config/db.inc.php");
-require_once("../../../../config/tools/users/alias_management/local.inc.php");
 require_once("lib/functions.inc.php");
 
 $page_name = basename($_SERVER['SCRIPT_NAME']);
@@ -31,6 +30,7 @@ $page_id = substr($page_name, 0, strlen($page_name) - 4);
 $_SESSION['current_tool'] = 'alias_management';
 $_SESSION['current_group'] = get_group();
 $no_result = "No Data Found.";
+session_load();
 ?>
 
 <html>

--- a/web/tools/users/user_management/params.php
+++ b/web/tools/users/user_management/params.php
@@ -1,10 +1,6 @@
 <?php
 
 $config->user_management = array(
-	"title0" => array(
-		"type" => "title",
-		"title" => "Section 1"
-	),
 	"table_users" => array(
 		"default" => "subscriber",
 		"name"    => "Table Users",
@@ -37,10 +33,6 @@ $config->user_management = array(
 		),
 		"name"    => "Table aliases",
 		"type"    => "json",
-	),
-	"title1" => array(
-		"type"  => "title",
-		"title" => "Section 2"
 	),
 	"passwd_mode" => array(
 		"default" => 0,

--- a/web/tools/users/user_management/params.php
+++ b/web/tools/users/user_management/params.php
@@ -1,6 +1,10 @@
 <?php
 
 $config->user_management = array(
+	"title0" => array(
+		"type" => "title",
+		"title" => "Section 1"
+	),
 	"table_users" => array(
 		"default" => "subscriber",
 		"name"    => "Table Users",
@@ -33,6 +37,10 @@ $config->user_management = array(
 		),
 		"name"    => "Table aliases",
 		"type"    => "json",
+	),
+	"title1" => array(
+		"type"  => "title",
+		"title" => "Section 2"
 	),
 	"passwd_mode" => array(
 		"default" => 0,

--- a/web/tools/users/user_management/show_contacts.php
+++ b/web/tools/users/user_management/show_contacts.php
@@ -1,10 +1,9 @@
 <?php
 
-require_once("../../../../config/tools/users/user_management/local.inc.php");
 require_once("../../../common/mi_comm.php");
 require_once("../../../common/cfg_comm.php");
 require_once("lib/functions.inc.php");
-
+session_load();
 
 $mi_connectors=get_proxys_by_assoc_id(get_value('talk_to_this_assoc_id'));
 $message=mi_command( "ul_show_contact", array("table_name"=>"location","aor"=>$_GET["username"]."@".$_GET["domain"]), $mi_connectors[0], $errors);

--- a/web/tools/users/user_management/template/header.php
+++ b/web/tools/users/user_management/template/header.php
@@ -23,13 +23,13 @@
 require_once("../../../../config/session.inc.php");
 require_once("../../../../config/tools/users/user_management/db.inc.php");
 require_once("../../../../config/db.inc.php");
-require_once("../../../../config/tools/users/user_management/local.inc.php");
 require_once("lib/functions.inc.php");
 $page_name = basename($_SERVER['SCRIPT_NAME']);
 $page_id = substr($page_name, 0, strlen($page_name) - 4);
 $_SESSION['current_tool'] = $page_id;
 $_SESSION['current_group'] = get_group();
 $no_result = "No Data Found.";
+session_load();
 header('Content-Type: text/html; charset=ISO-8859-1');
 ?>
 

--- a/web/tools/users/user_management/user_management.php
+++ b/web/tools/users/user_management/user_management.php
@@ -1,9 +1,4 @@
 <?php
-function console_log( $data ){
-	echo '<script>';
-	echo 'console.log('. json_encode( $data ) .')';
-	echo '</script>';
-  } //  DE_STERS
 /*
 * Copyright (C) 2011 OpenSIPS Project
 *

--- a/web/tools/users/user_management/user_management.php
+++ b/web/tools/users/user_management/user_management.php
@@ -1,4 +1,9 @@
 <?php
+function console_log( $data ){
+	echo '<script>';
+	echo 'console.log('. json_encode( $data ) .')';
+	echo '</script>';
+  } //  DE_STERS
 /*
 * Copyright (C) 2011 OpenSIPS Project
 *


### PR DESCRIPTION
Tools that are able to rely completely on the db settings engine shouldn't use old config files (local.inc.php),
so they were removed.