### PR TITLE
Fix parameters loading in get_domains function

### DIFF
--- a/web/tools/system/domains/lib/functions.inc.php
+++ b/web/tools/system/domains/lib/functions.inc.php
@@ -28,7 +28,7 @@ function get_domains($module, $has_any)
 	require("../../../../config/db.inc.php");
 	require("../../../../config/tools/system/domains/db.inc.php");
 	require("db_connect.php");
-	session_load();
+	session_load_from_tool("domains");
 	
 	$table_domains=$config->table_domains;
 


### PR DESCRIPTION
Fix bug where session_loading() function loaded parameters for wrong tool (the tool that called the function, instead of domains tool that was intended).