### PR TITLE
Clean old config files from cron_job folder

### DIFF
--- a/cron_job/cdr_export.php
+++ b/cron_job/cdr_export.php
@@ -24,7 +24,8 @@
 $path_to_cdrviewer="/var/www/html/opensips-cp/web/tools/system/cdrviewer";
 chdir($path_to_smonitor);
 require("../../../../config/db.inc.php");
-require("../../../../config/tools/system/cdrviewer/local.inc.php");
+require("../../../../web/common/cfg_comm.php");
+session_load_from_tool("cdrviewer");
 require("../../../../config/tools/system/cdrviewer/db.inc.php");
 require("lib/functions.inc.php");
 require("lib/db_connect.php");

--- a/cron_job/clean_statistics.php
+++ b/cron_job/clean_statistics.php
@@ -23,9 +23,10 @@
 
 chdir("web/tools/system/smonitor");
 require("../../../../config/db.inc.php");
-require("../../../../config/tools/system/smonitor/local.inc.php");
 require("lib/functions.inc.php");
 require("../../../../web/common/mi_comm.php");
+require_once("../../../../web/common/cfg_comm.php");
+session_load_from_tool("smonitor");
 require("../../../../config/boxes.global.inc.php");
 require("lib/db_connect.php");
 

--- a/cron_job/get_opensips_stats.php
+++ b/cron_job/get_opensips_stats.php
@@ -23,8 +23,8 @@
 
 chdir("web/tools/system/smonitor");
 require("../../../../config/db.inc.php");
-require("../../../../config/tools/system/smonitor/local.inc.php");
 require("../../../../web/common/cfg_comm.php");
+session_load_from_tool("smonitor");
 require("lib/functions.inc.php");
 require("../../../../web/common/mi_comm.php");
 require("../../../../config/boxes.global.inc.php");


### PR DESCRIPTION
Remove the last of old config files requirements from the cron_job_folder. (#134)