### PR TITLE
Change db inserting statements for admin tools

### DIFF
--- a/web/tools/admin/system_config/system_config.php
+++ b/web/tools/admin/system_config/system_config.php
@@ -49,23 +49,26 @@ if ($action=="modify_params")
         $system_params=get_system_params();
 		$params_names = "";
 		$unknowns ="";
+		$update_query ="";
 		$values = array();
 		foreach ($system_params as $attr => $params){
 			if ($params['show_in_edit_form']) {
+				$update_query .= "`".$attr."`=?, ";
 				$params_names.="`".$attr."`, ";
 				$unknowns.="?, ";
 				$values[] = $_POST[$attr];
 			}
 		}
+		$update_query.="`assoc_id`=?;";
 		$params_names.="assoc_id";
 		$unknowns.="?";
 		$values[] = $assoc_id;
-		$sql = "REPLACE INTO $table (".$params_names.") VALUES (".$unknowns.")";
+		$sql = "INSERT INTO $table (".$params_names.") VALUES (".$unknowns.") ON DUPLICATE KEY UPDATE ".$update_query;
 		$stm = $link->prepare($sql);
 		if ($stm === false) {
 		die('Failed to issue query ['.$sql.'], error message : ' . print_r($link->errorInfo(), true));
 		}
-		if ($stm->execute( $values) == false) {
+		if ($stm->execute(array_merge($values, $values)) == false) {
 			$errors= "Updating record in DB failed: ".print_r($stm->errorInfo(), true); 
 		}    else {
 			$info="Systems were modified";

--- a/web/tools/admin/tools_config/tools_config.php
+++ b/web/tools/admin/tools_config/tools_config.php
@@ -51,12 +51,12 @@ if ($action=="modify_params")
 						$_POST[$module] = $checklist_values;
 					}
 					
-					$sql = "REPLACE INTO $table (module, param, value) VALUES (?,?,?)";
+					$sql = "INSERT INTO $table (module, param, value) VALUES (?,?,?) ON DUPLICATE KEY UPDATE module=?,param=?,value=?";
 					$stm = $link->prepare($sql);
 					if ($stm === false) {
 					die('Failed to issue query ['.$sql.'], error message : ' . print_r($link->errorInfo(), true));
 				}
-					if ($stm->execute( array( $current_tool, $module, $_POST[$module])) == false) {
+					if ($stm->execute( array( $current_tool, $module, $_POST[$module], $current_tool, $module, $_POST[$module])) == false) {
 						$errors= "Updating record in DB failed: ".print_r($stm->errorInfo(), true); 
 					}    else {
 						$info="Admin credentials were modified";


### PR DESCRIPTION
Change REPLACE statement to INSERT ON DUPLICATE KEY UPDATE, so that unspecified values don't disappear when not specified.