### PR TITLE
Add missing CDR table name parameter

### DIFF
--- a/web/tools/system/cdrviewer/params.php
+++ b/web/tools/system/cdrviewer/params.php
@@ -1,6 +1,12 @@
 <?php
 
 $config->cdrviewer = array(
+	"cdr_table" => array(
+		"default" => "acc",
+		"name"    => "CDR table",
+		"type"    => "text",
+		"validation_regex" => null,
+	),
     "results_per_page" => array(
 		"default" => 25,
 		"name"    => "Results per page",


### PR DESCRIPTION
CDR table parameter was not included in the config file of the CDR Viewer tool.