### PR TITLE
Missing semicolon

### DIFF
--- a/config/db_schema.mysql
+++ b/config/db_schema.mysql
@@ -69,7 +69,7 @@ CREATE TABLE `ocp_system_config` (
   `name` varchar(64) DEFAULT NULL,
   `desc` varchar(64) DEFAULT '',
   PRIMARY KEY (`assoc_id`)
-)
+);
 
 -- --------------------------------------------------------
 
@@ -85,4 +85,4 @@ CREATE TABLE `ocp_tools_config` (
   `box_id` varchar(15) DEFAULT '',
   PRIMARY KEY (`id`),
   UNIQUE KEY `box_key` (`module`,`param`,`box_id`)
-) 
+);


### PR DESCRIPTION
Missing semicolon to create tables `ocp_system_config` and `ocp_tools_config`