### PR TITLE
smonitor: add more details to stats

### DIFF
--- a/web/tools/system/dialog/statistics/stats1.php
+++ b/web/tools/system/dialog/statistics/stats1.php
@@ -9,7 +9,7 @@ class stats1 extends custom_statistic
     }
     
     public static function get_description() {
-        $desc = "this is the description 1";
+        $desc = "This class gets the dialog size of a profile";
         return $desc;
     }
 

--- a/web/tools/system/smonitor/lib/functions.inc.js
+++ b/web/tools/system/smonitor/lib/functions.inc.js
@@ -1,6 +1,6 @@
 <script>
-function show_statistic(description, input){
-    url = "template/statistics.details.php?input="+input+"&description="+description;
+function openStatOverlay(description, className, input, tool){
+    url = "template/statistics.details.php?class="+className+"&description="+description+"&tool="+tool+"&input="+input;
     var http = getHTTPObject();
     
     http.open("GET", url, false);
@@ -20,13 +20,41 @@ function show_statistic(description, input){
     document.getElementById('overlay').style.display = 'block';
     document.getElementById('custom_stat').innerHTML = result;
     centerMe('custom_stat')
-    document.getElementById('overlay').onclick = function () {closeDialog();};
+    document.getElementById('overlay').onclick = function () {closeStatOverlay();};
     document.getElementById('custom_stat').style.display = 'block';
     window.location.hash = '#tab1';
     location.hash = "tab1";
   
   }
   
+  function openImportOverlay(description){
+    url = "template/statistics.import_details.php?description="+description;
+    var http = getHTTPObject();
+    
+    http.open("GET", url, false);
+    http.onreadystatechange = handleHttpResponse(http);
+    http.send(null);
+    result = http.responseText;
+    
+    var body = document.body,
+      html = document.documentElement;
+  
+    var height = Math.max( body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight );
+    var width = Math.max( body.scrollWidth, body.offsetWidth, html.clientWidth, html.scrollwidth, html.offsetwidth );
+  
+  
+    document.getElementById('overlay').style.height = height;
+    document.getElementById('overlay').style.width = width;
+    document.getElementById('overlay').style.display = 'block';
+    document.getElementById('custom_stat').innerHTML = result;
+    centerMe('custom_stat')
+    document.getElementById('overlay').onclick = function () {closeImportOverlay();};
+    document.getElementById('custom_stat').style.display = 'block';
+    window.location.hash = '#tab1';
+    location.hash = "tab1";
+  
+  }
+
   function centerMe(element) {
     //pass element name to be centered on screen
       var pWidth = window.innerWidth;
@@ -40,13 +68,20 @@ function show_statistic(description, input){
     
     
     
-    function closeDialog() {
+    function closeStatOverlay() {
       document.getElementById('overlay').style.display = 'none';
       document.getElementById('custom_stat').style.display = 'none';
       document.getElementById('custom_stat').innerHTML = '';
       location.hash = "";
     }
   
+  function closeImportOverlay() {
+      document.getElementById('overlay').style.display = 'none';
+      document.getElementById('custom_stat').style.display = 'none';
+      document.getElementById('custom_stat').innerHTML = '';
+      location.hash = "";
+    }
+
   function handleHttpResponse(http) {
 
 if (http.readyState == 4) {

--- a/web/tools/system/smonitor/statistics.php
+++ b/web/tools/system/smonitor/statistics.php
@@ -32,12 +32,16 @@
  
  session_load(); 
  $stat_classes = get_stats_classes();
- 
+ $current_page="current_statistics";
+
  include("lib/db_connect.php");
 
 if (isset($_POST['action'])) $action=$_POST['action'];
 else if (isset($_GET['action'])) $action=$_GET['action'];
 else $action="";
+
+if (isset($_GET['page'])) $_SESSION[$current_page]=$_GET['page'];
+else if (!isset($_SESSION[$current_page])) $_SESSION[$current_page]=1;
 
 if ($action == "import_statistic") {
 	$stat_class = $_GET['class'];

--- a/web/tools/system/smonitor/template/statistics.add.php
+++ b/web/tools/system/smonitor/template/statistics.add.php
@@ -27,8 +27,8 @@ if(!$_SESSION['read_only']){
 }
 ?>
 
-<div id="dialog" class="dialog" style="display:none"></div>
-<div onclick="closeDialog();" id="overlay" style="display:none"></div>
+<div id="custom_stat" class="dialog" style="display:none"></div>
+<div onclick="closeImportOverlay();" id="overlay" style="display:none"></div>
 <div id="content" style="display:none"></div>
 
 
@@ -37,6 +37,7 @@ if(!$_SESSION['read_only']){
   <th class="listTitle">Statistic name</th>
   <th class="listTitle">Statistic class name</th>
   <th class="listTitle">Provisioning tool</th>
+  <th class="listTitle">Provisioning details</th>
   <?php
   if(!$_SESSION['read_only']){
   	echo('<th class="listTitle">Import</th>');
@@ -70,6 +71,7 @@ else
 		$index_row++;
 		if ($index_row%2==1) $row_style="rowOdd";
 		else $row_style="rowEven";
+			$details_link = '<a href="javascript:;" onclick="openImportOverlay(\''.$stat_temp::get_description().'\')"><img src="../../../images/share/details.png" border="0"></a>';
 			//$details_link = '<a href="javascript:;" onclick="show_statistic(\''.$resultset[$i].'\')"><img src="../../../images/share/details.png" border="0"></a>';
             //$details_link = '<a href="'.$page_name.'?action=import_details&widget_dir='.$resultset[$i]['dir'].'"><img src="../../../images/share/details.png" border="0"></a>';
 			if(!$_SESSION['read_only']){	
@@ -80,6 +82,7 @@ else
   <td class="<?=$row_style?>">&nbsp;<?php print $stat_temp->get_name();?></td>
   <td class="<?=$row_style?>">&nbsp;<?php print $resultset[$i]?></td>
   <td class="<?=$row_style?>">&nbsp;<?php print $stat_temp->get_tool();?></td>
+  <td class="<?=$row_style?>">&nbsp;<?php print $details_link?></td>
 <?php
    if(!$_SESSION['read_only']){
    	echo('

--- a/web/tools/system/smonitor/template/statistics.import_details.php
+++ b/web/tools/system/smonitor/template/statistics.import_details.php
@@ -20,36 +20,24 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
     $desc = $_GET['description'];
-    $class = $_GET['class'];
-    $tool = $_GET['tool'];
-    $input = $_GET['input'];
     
  ?>
 	<table width="400" border="0">
 		<tr>
 			<td class="mainTitle">
-					View statistic
+					Statistic description
 			</td>
 		</tr>
 
 		<tr>
 			<td>
+
 				<table class="ttable" width="100%" cellspacing="2" cellpadding="2" border="0"> <tr>
 				<?php
-                echo ('<td>Statistic description: '.$desc.'</td>');
+                echo ('<td style="height: 100px;" >Statistic description: '.$desc.'</td>');
                 ?>
-                </tr><tr><?php
-                echo ('<td>Statistic class: '.$class.'</td>'); ?></tr>
-				<tr><?php
-                echo ('<td>Provisioning tool: '.$tool.'</td>'); ?></tr>
-				<tr><?php
-                echo ('<td>Statistic input: '.$input.'</td>'); ?></tr></table>
-			</td>
-		</tr>
+                </tr></table>
 
-		<tr>
-			<td align="center">
-				<? print_back_input(); ?>
 			</td>
 		</tr>
 	

--- a/web/tools/system/smonitor/template/statistics.main.php
+++ b/web/tools/system/smonitor/template/statistics.main.php
@@ -31,7 +31,7 @@ if(!$_SESSION['read_only']){
 
 
 <div id="custom_stat" class="dialog" style="display:none"></div>
-<div onclick="closeDialog();" id="overlay" style="display:none"></div>
+<div onclick="closeStatOverlay();" id="overlay" style="display:none"></div>
 <div id="content" style="display:none"></div>
 
 <form action="<?=$page_name?>?action=add_statistic" method="post">
@@ -72,6 +72,7 @@ else
 		$_SESSION[$current_page]=$page;
 	}
 	$start_limit=($page-1)*$res_no;
+
 	//$sql_command.=" limit ".$start_limit.", ".$res_no;
 	$resultset = get_custom_statistics();
 	$index_row=0;
@@ -81,9 +82,8 @@ else
 		$index_row++;
 		if ($index_row%2==1) $row_style="rowOdd";
 		else $row_style="rowEven";
-
 		if(!$_SESSION['read_only']){
-			$details_link = '<a href="javascript:;" onclick="show_statistic(\''.$resultset[$i]['class']::get_description().'\',\''.$resultset[$i]['name'].'\')"><img src="../../../images/share/details.png" border="0"></a>';
+			$details_link = '<a href="javascript:;" onclick="openStatOverlay(\''.$resultset[$i]['class']::get_description().'\',\''.$resultset[$i]['class'].'\',\''.$resultset[$i]['input'].'\',\''.$resultset[$i]['tool'].'\')"><img src="../../../images/share/details.png" border="0"></a>';
 			$delete_link='<a href="'.$page_name.'?action=delete&stat_id='.$resultset[$i]['id'].'"><img src="../../../images/share/delete.png" border="0"></a>';
 			$edit_link = '<a href="'.$page_name.'?action=edit_statistic&stat_id='.$resultset[$i]['id'].'"><img src="../../../images/share/edit.png" border="0"></a>';
 		}


### PR DESCRIPTION
Add extra details to imported stats, and add description overlay for stats that are available for importing. Also fix paging issue where page numbers didn't display properly.