### PR TITLE
Fix warnings and notices related to smonitor tool

### DIFF
--- a/config/boxes.load.php
+++ b/config/boxes.load.php
@@ -47,7 +47,7 @@ if (!isset($boxes)) {
         $box_id = $elem['id'];
         $boxes[$i]['id'] = $box_id;
         foreach ($config->boxes as $param => $attr) {
-            if ($attr['nodes'] != null) {
+            if (isset($attr['nodes'])) {
                 $boxes[$i][$attr['nodes'][0]][$attr['nodes'][1]] = $elem[$param];
             }
             $boxes[$i][$param] = $elem[$param];

--- a/config/tools/system/smonitor/settings.inc.php
+++ b/config/tools/system/smonitor/settings.inc.php
@@ -21,6 +21,9 @@
  */
 	global $table_regex;
 
+if (!isset($config)) 
+    $config = new stdClass();
+
 $config->smonitor = array(
 	"title0" => array(
 		"type" => "title",

--- a/web/common/cfg_comm.php
+++ b/web/common/cfg_comm.php
@@ -330,7 +330,7 @@ function get_settings_value_from_tool($current_param, $current_tool, $box_id = n
 		if (!is_null($_SESSION['config'][$current_tool][$box_id][$current_param])) {
 			return $_SESSION['config'][$current_tool][$box_id][$current_param];}}
 	foreach($config->$current_tool as $module=>$params) {
-		if ($module == $current_param) return $params['default'];
+		if ($module == $current_param && $params['type'] != "title") return $params['default'];
 	}
 
 	return null;

--- a/web/common/mi_comm.php
+++ b/web/common/mi_comm.php
@@ -91,7 +91,7 @@ function mi_command($command, $params_array, $mi_url, &$errors)
 	$output = write2json( trim($command), $params_array, substr($mi_url,5)/*URL*/, $errors);
 
 	/* print here only the errors from MI level (bad param, no cmd, etc), but not errors from cmd level */
-	if ($errors && $errors["code"]<0) {
+	if (isset($errors["code"]) && $errors["code"]<0) {
 		echo "<font color='red'>"."MI command failed with code ".$errors["code"]." (".$errors["message"].")"."</font>";
 	}
 

--- a/web/tools/admin/tools_config/template/tools_config.edit_tools.php
+++ b/web/tools/admin/tools_config/template/tools_config.edit_tools.php
@@ -24,33 +24,29 @@ require_once("../../../common/forms.php");
 require_once("../../../common/cfg_comm.php");
 require_once("../../../../config/boxes.global.inc.php");
 require_once("functions.js");
- if (isset($form_error)) {
-                          echo(' <tr align="center">');
-                          echo('  <td colspan="2" class="dataRecord"><div class="formError">'.$form_error.'</div></td>');
-                          echo(' </tr>');
-                         }
-	$id=$_GET['id'];
-	$box_id=$_GET['box_id'];
+	if (isset($form_error)) {
+		echo(' <tr align="center">');
+		echo('  <td colspan="2" class="dataRecord"><div class="formError">'.$form_error.'</div></td>');
+		echo(' </tr>');
+	}
+	
+	unset($box_id);
+	if (isset($_GET['box_id']))
+		$box_id=$_GET['box_id'];
+	else $box_id = null;
+
 	$current_tool=$_SESSION['current_tool'];
 	$current_tool_name = get_tool_name();
 
-	$sql = "select * from ".$table." where id=?";
-	$stm = $link->prepare($sql);
-
-	if ($stm === false) {
-	  	die('Failed to issue query ['.$sql.'], error message : ' . print_r($link->errorInfo(), true));
-	}
-	$stm->execute( array($id) );
-	$resultset = $stm->fetchAll(PDO::FETCH_ASSOC);
-        $index_row=0;
-$permissions=array();
+    $index_row=0;
+	$permissions=array();
 ?> 
 
 <form action="<?=$page_name?>?action=modify_params&tool=<?=$current_tool?>&box_id=<?=$box_id?>" method="post">
 <table width="400" cellspacing="2" cellpadding="2" border="0">
  <tr align="center">
 	 <?php   
-	 if(is_null($box_id)) { ?>
+	 if(!isset($box_id)) { ?>
  <td colspan="3" height="10" class="mainTitle">Settings for <?=$current_tool_name?></td>
  <?php  } else { ?>
  <td colspan="3" height="10" class="mainTitle">Settings for <?=$current_tool_name?> for <?=$boxes[$box_id]['desc']?></td>
@@ -60,9 +56,9 @@ $permissions=array();
 	$tools_params=get_params();
 	
 	foreach ($tools_params as $module=>$params) {
-		if ($params['opt']) $opt = "y"; else $opt = "n";
-		if ($params['tip'])
-			$current_tip = $params[tip];
+		if (isset($params['opt'])) $opt = "y"; else $opt = "n";
+		if (isset($params['tip']))
+			$current_tip = $params['tip'];
 		else $current_tip = null;
 		switch ($params['type']) {
 			case "checklist":
@@ -73,9 +69,9 @@ $permissions=array();
 			case "json":
 				$flags = JSON_PRETTY_PRINT;
 				$validation = "validate_json";
-				if ($params['json_format'] == "object")
+				if (isset($params['json_format']) && $params['json_format'] == "object")
 					$flags |= JSON_FORCE_OBJECT;
-				form_generate_input_textarea($params['name'], $current_tip, $module, $opt, json_encode(get_settings_value($module, $box_id), $flags), (isset($params['maxlen'])?$params['maxlen']:NULL), $params['validation_regex'], $validation, $params['json_format']);
+				form_generate_input_textarea($params['name'], $current_tip, $module, $opt, json_encode(get_settings_value($module, $box_id), $flags), (isset($params['maxlen'])?$params['maxlen']:NULL), (isset($params['validation_regex'])?$params['validation_regex']:NULL), $validation, (isset($params['json_format'])?$params['json_format']:NULL));
 				break;
 			case "dropdown": 
 				if (isAssoc($params['options']))
@@ -86,9 +82,9 @@ $permissions=array();
 					print '<tr> <td class=\'sectionTitle\'><b>'.$params['title'].'</b></td></tr>';
 				break;
 			default:
-				form_generate_input_text($params['name'], $current_tip, $module, $opt, get_settings_value($module, $box_id), 100, $params['validation_regex']);
+				form_generate_input_text($params['name'], $current_tip, $module, $opt, get_settings_value($module, $box_id), 100,(isset($params['validation_regex'])?$params['validation_regex']:NULL));
 		}
-		if ($params['example']) {
+		if (isset($params['example'])) {
 			print_example($params['example'], $params['name'], $module);
 		}
 	}

--- a/web/tools/admin/tools_config/tools_config.php
+++ b/web/tools/admin/tools_config/tools_config.php
@@ -29,8 +29,12 @@ include("lib/db_connect.php");
 require("../../../../config/globals.php");
 $table=$config->table_tools_config; 
 $current_page="current_page_tools_config";
-$box_id = $_GET['box_id'];
-if ($box_id == '') $box_id = null;
+
+unset($box_id);
+if (isset($_GET['box_id'])) {
+	$box_id = $_GET['box_id'];
+	if ($box_id == '') $box_id = null;
+}
 
 if (isset($_POST['action'])) $action=$_POST['action'];
 else if (isset($_GET['action'])) $action=$_GET['action'];
@@ -43,7 +47,7 @@ if ($action=="modify_params")
 		$current_tool=$_GET['tool'];
         $tools_params=get_params();
 		foreach($tools_params as $param => $attr) {
-			if ($attr['validation_regex']) {
+			if (isset($attr['validation_regex'])) {
 				if (!preg_match("/".$attr['validation_regex']."/", $_POST[$param])) {
 					die("Failed to validate input for ".$attr['name']);
 				}

--- a/web/tools/system/smonitor/charts.php
+++ b/web/tools/system/smonitor/charts.php
@@ -26,7 +26,7 @@
  require("../../../../config/db.inc.php"); 
  require("lib/functions.inc.php");
 
- session_start();  
+ require("../../../../config/session.inc.php");
  require("template/header.php");
  include("lib/db_connect.php");
  session_load();
@@ -37,19 +37,19 @@
 
  $gauge_arr = get_vars_type($current_box);
  
- if ($_GET['stat_id']!=null)
+ if (isset($_GET['stat_id']))
  {
   $stat_id = $_GET['stat_id'];
   if ($_SESSION['stat_open'][$stat_id]=="yes") $_SESSION['stat_open'][$stat_id]="no";
    else $_SESSION['stat_open'][$stat_id]="yes";
  }
- if ($_GET['group_id']!=null) {
+ if (isset($_GET['group_id'])) {
    $group_id = $_GET['group_id'];
    if ($_SESSION['group_open'][$group_id] == "yes") $_SESSION['group_open'][$group_id]="no";
    else $_SESSION['group_open'][$group_id]="yes";
  }  
  
- if ($_POST['flush']!=null)
+ if (isset($_POST['flush']))
  {
   $sql = "DELETE FROM ".get_settings_value("table_monitoring")." WHERE box_id = ?";
   $stm = $link->prepare($sql);
@@ -59,7 +59,7 @@
  
  $expanded=false;
  for($i=0; $i<sizeof($_SESSION['stat_open']); $i++)
-  if ($_SESSION["stat_open"][$i]=="yes") $expanded=true;
+  if (isset($_SESSION["stat_open"][$i]) && $_SESSION["stat_open"][$i] == "yes") $expanded=true;
  
  require("template/".$page_id.".main.php");
  require("template/footer.php");

--- a/web/tools/system/smonitor/get_data.php
+++ b/web/tools/system/smonitor/get_data.php
@@ -1,5 +1,5 @@
 <?php
-	session_start();
+	require_once("../../../../config/session.inc.php");
     require_once("../../../../config/tools/system/smonitor/db.inc.php");
     require_once("../../../../config/db.inc.php");
     

--- a/web/tools/system/smonitor/get_multiple_data.php
+++ b/web/tools/system/smonitor/get_multiple_data.php
@@ -1,5 +1,5 @@
 <?php
-	session_start();
+	require_once("../../../../config/session.inc.php");
     require_once("../../../../web/common/cfg_comm.php");
     require_once("../../../../config/tools/system/smonitor/db.inc.php");
     require_once("../../../../config/db.inc.php");

--- a/web/tools/system/smonitor/index.php
+++ b/web/tools/system/smonitor/index.php
@@ -27,7 +27,7 @@
  require("../../../common/cfg_comm.php"); 
  require("lib/functions.inc.php");
 
- session_start();
+ require_once("../../../../config/session.inc.php");
  get_priv("smonitor");
 
  header("Location: rt_stats.php");

--- a/web/tools/system/smonitor/lib/functions.inc.php
+++ b/web/tools/system/smonitor/lib/functions.inc.php
@@ -104,7 +104,7 @@ function get_custom_modules()
 	$module_counter = [];
 
 	foreach($modules as $module) {
-		if ($module_counter[$module['tool']])
+		if (isset($module_counter[$module['tool']]))
 			$module_counter[$module['tool']]++;
 		else $module_counter[$module['tool']] = 1;
 	}
@@ -241,7 +241,8 @@ function clean_stats_table(){
 function show_boxes($boxen){
 
 global $current_box;
-global $page_name ;  
+global $page_name;
+global $box_val;  
 
 echo ('<form action="'.$page_name.'?action=change_box&box_val="'.$box_val.' method="post" name="boxen_select" style="margin:0px!important">');
 echo ('<input type="hidden" name="box_val" class="formInput" method="post" value="">');

--- a/web/tools/system/smonitor/lib/put_select_boxes.php
+++ b/web/tools/system/smonitor/lib/put_select_boxes.php
@@ -21,8 +21,7 @@
  */
 
  require_once("../../../common/cfg_comm.php");
-
- session_start(); 
+ require_once("../../../../config/session.inc.php");
 
  $current_box=$_SESSION['smon_current_box'];  
 

--- a/web/tools/system/smonitor/rt_stats.php
+++ b/web/tools/system/smonitor/rt_stats.php
@@ -25,7 +25,7 @@
  require("../../../../config/tools/system/smonitor/db.inc.php");
  require("../../../../config/db.inc.php");
  require("lib/functions.inc.php");
- session_start(); 
+ require("../../../../config/session.inc.php");
  require("template/header.php");
  
  session_load(); 
@@ -37,7 +37,7 @@
  include("lib/db_connect.php");
  
  
- if ($_GET['var']!=null)
+ if (isset($_GET['var']))
  {
   $var_name = $_GET['var'];
   $sql = "SELECT * FROM ".$table." WHERE name = ? AND box_id = ?";
@@ -58,14 +58,14 @@
 	}
  }
 
- if ($_GET['module_id']!=null)
+ if (isset($_GET['module_id']))
  { 
   $module_id = $_GET['module_id'];
   if ($_SESSION['module_open'][$module_id]=="yes") $_SESSION['module_open'][$module_id]="no";
    else $_SESSION['module_open'][$module_id]="yes";
  }
 
- if ($_GET['custom_module_id']!=null)
+ if (isset($_GET['custom_module_id']))
  { 
   $module_id = $_GET['custom_module_id']; 
   if ($_SESSION['custom_module_open'][$module_id]=="yes") $_SESSION['custom_module_open'][$module_id]="no";
@@ -80,7 +80,7 @@
  for($i=0; $i<$_SESSION['custom_modules_no']; $i++)
   if ($_SESSION["custom_module_open"][$i]=="yes") $expanded=true;
  
- if ($_POST['reset_stats']!=null){
+ if (isset($_POST['reset_stats'])){
   $reset=$_POST['reset'];
   for($i=0; $i<sizeof($reset); $i++)
   if ($reset[$i]!=null) reset_var($reset[$i], $current_box);

--- a/web/tools/system/smonitor/template/charts.main.php
+++ b/web/tools/system/smonitor/template/charts.main.php
@@ -77,7 +77,7 @@ else
 
  $stat_chart=false;
  $stat_img="../../../images/share/chart.png";
- if ($_SESSION["group_open"][$key]=="yes") $stat_chart=true;
+ if (isset($_SESSION["group_open"][$key]) && $_SESSION["group_open"][$key]=="yes") $stat_chart=true;
  $sql = "SELECT min(time) as time FROM ".$table." WHERE box_id = ? AND name IN (".implode(",",array_fill(0, count($group), "?")).") ORDER BY time ASC LIMIT 1";
  $stm = $link->prepare($sql);
  if ($stm->execute(array_merge(array($box_id), $group)) === false)
@@ -108,14 +108,13 @@ else
   $stat_chart=false;
   $stat=$resultset[$j]['name'];
   $stat_img="../../../images/share/chart.png";
-  if ($_SESSION["stat_open"][$i]=="yes") $stat_chart=true;
+  if (isset($_SESSION["stat_open"][$i]) && $_SESSION["stat_open"][$i]=="yes") $stat_chart=true;
   $sql = "SELECT * FROM ".$table." WHERE name = ? AND box_id = ? ORDER BY time ASC LIMIT 1";
   $stm = $link->prepare($sql);
   if ($stm->execute(array($stat, $box_id)) === false)
     die('Failed to issue query, error message : ' . print_r($stm->errorInfo(), true));
   $result = $stm->fetchAll(PDO::FETCH_ASSOC);
   $from_time=date('j M Y, H:i:s',$result[0]['time']);
-  echo $result['time'];
   ?>
    <tr>
     <td class="searchRecord">

--- a/web/tools/system/smonitor/template/menu.php
+++ b/web/tools/system/smonitor/template/menu.php
@@ -20,7 +20,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-session_start(); 
+require_once("../../../../config/session.inc.php");
 
 $current_box=$_SESSION['smon_current_box'];  
 


### PR DESCRIPTION
Fixed various warnings and notices related to smonitor tool and the settings engine. Mostly start using the isset() function instead of checking the variable directly, and initialize them properly.