### PR TITLE
Remove warning from widgets that don't implement it, make dashboard starting page

### DIFF
--- a/web/auth_login.php
+++ b/web/auth_login.php
@@ -54,6 +54,17 @@ if ($g->checkCode($secret, $otp)) {
 	$_SESSION['user_tabs'] = $_SESSION['temp_user_tabs'];
 	$_SESSION['user_priv'] = $_SESSION['temp_user_priv'];
 
+	$query = "SELECT COUNT(*) as panel_no FROM ocp_dashboard;";
+	$stmt = $link->prepare($query);
+	if (!$stmt->execute(array($name))) {
+		print_r("Failed to fetch db!");
+		error_log(print_r($stmt->errorInfo(), true));
+		die;
+	}
+	$resultset = $stmt->fetchAll();
+	if ($resultset[0]['panel_no'] > 0)
+		$_SESSION['path'] = "tools/admin/dashboard/dashboard.php";
+	
 	header("Location:main.php");
 } else {
 	print_r("Incorrect code");

--- a/web/login.php
+++ b/web/login.php
@@ -166,6 +166,19 @@ else {
 	$_SESSION['user_login'] = $_SESSION['temp_user_login'];
 	$_SESSION['user_tabs'] = $_SESSION['temp_user_tabs'];
 	$_SESSION['user_priv'] = $_SESSION['temp_user_priv'];
+
+
+	$query = "SELECT COUNT(*) as panel_no FROM ocp_dashboard;";
+	$stmt = $link->prepare($query);
+	if (!$stmt->execute(array($name))) {
+		print_r("Failed to fetch db!");
+		error_log(print_r($stmt->errorInfo(), true));
+		die;
+	}
+	$resultset = $stmt->fetchAll();
+	if ($resultset[0]['panel_no'] > 0)
+		$_SESSION['path'] = "tools/admin/dashboard/dashboard.php";
+	
 	header("Location:main.php");
 }
 exit();

--- a/web/main.php
+++ b/web/main.php
@@ -28,6 +28,10 @@ if (!isset($_SESSION['user_login'])) {
 }
 
 $main_body="blank.php";
+if (isset($_SESSION['path'])) {
+	$main_body = $_SESSION['path'];
+	unset($_SESSION['path']);
+}
 if (isset($_SESSION['current_tool'])) {
 	foreach ($config_modules as $menuitem => $menuitem_config) {
 		if (!$menuitem_config['enabled'])

--- a/web/tools/admin/dashboard/template/dashboard_widgets/gauge_widget.php
+++ b/web/tools/admin/dashboard/template/dashboard_widgets/gauge_widget.php
@@ -21,6 +21,7 @@ class gauge_widget extends widget
 			if ($box['id'] == $this->box_id)
 				$this->widget_box = $box;
 		}
+		$this->set_warning(1);
     }
 
     function display_chart($title, $value, $valueMax = 100) {

--- a/web/tools/admin/dashboard/template/dashboard_widgets/pkg_widget.php
+++ b/web/tools/admin/dashboard/template/dashboard_widgets/pkg_widget.php
@@ -14,6 +14,7 @@ class pkg_widget extends widget
     function __construct($array) {
         parent::__construct($array['panel_id'], $array['widget_title'], 2, 3, $array['widget_title']);
 		$this->box_id = $array['widget_box'];
+		$this->set_warning(1);
 		foreach ($_SESSION['boxes'] as $box) {
 			if ($box['id'] == $this->box_id)
 				$this->widget_box = $box;

--- a/web/tools/admin/dashboard/template/dashboard_widgets/shmem_widget.php
+++ b/web/tools/admin/dashboard/template/dashboard_widgets/shmem_widget.php
@@ -8,6 +8,7 @@ class shmem_widget extends gauge_widget
 
     function __construct($array) {
         parent::__construct($array);
+		$this->set_warning(1);
         $this->color = 'rgb(198,226,213)';
 		$this->sizeX = 2;
     }

--- a/web/tools/admin/dashboard/template/dashboard_widgets/status_report_widget.php
+++ b/web/tools/admin/dashboard/template/dashboard_widgets/status_report_widget.php
@@ -11,6 +11,7 @@ class status_report_widget extends widget
 
     function __construct($array) {
         parent::__construct($array['panel_id'], $array['widget_name'], 2,2, $array['widget_name']);
+		$this->set_warning(1);
 		$this->box_id = $array['widget_box'];
 		foreach ($_SESSION['boxes'] as $box) {
 			if ($box['id'] == $this->box_id)

--- a/web/tools/admin/dashboard/template/widget/widget.php
+++ b/web/tools/admin/dashboard/template/widget/widget.php
@@ -10,7 +10,7 @@ abstract class widget
     public $color;
     public $has_menu;
     public $panel_id;
-	public $warning_level = 1;
+	public $warning_level = 0;
 
     public function __construct($panel_id, $name, $sizeX, $sizeY, $title=null) {
         $this->panel_id = $panel_id;
@@ -43,6 +43,9 @@ abstract class widget
 		$this->echo_content();
 				
 		switch ($this->warning_level) {
+			case 0:
+				$warning_color = "#3E5771";
+				break;
 			case 1:
 				$warning_color = "chartreuse";
 				break;
@@ -106,6 +109,8 @@ abstract class widget
 			$this->warning_level = 3;
 		if ($level == 2 && $this->warning_level != 3)
 			$this->warning_level = 2;
+		if ($level == 1 && $this->warning_level < 2)
+			$this->warning_level = 1;
 	}
 }
 ?>

--- a/web/tools/system/dispatcher/template/dashboard_widgets/dispatching_widget.php
+++ b/web/tools/system/dispatcher/template/dashboard_widgets/dispatching_widget.php
@@ -12,6 +12,7 @@ class dispatching_widget extends widget
     function __construct($array) {
         parent::__construct($array['panel_id'], $array['widget_name'], 2,2, $array['widget_name']);
 		$this->box_id = $array['widget_box'];
+		$this->set_warning(1);
 		foreach ($_SESSION['boxes'] as $box) {
 			if ($box['id'] == $this->box_id)
 				$this->widget_box = $box;

--- a/web/tools/system/drouting/template/dashboard_widgets/gateways_widget.php
+++ b/web/tools/system/drouting/template/dashboard_widgets/gateways_widget.php
@@ -12,6 +12,7 @@ class gateways_widget extends widget
     function __construct($array) {
         parent::__construct($array['panel_id'], $array['widget_name'], 2,2, $array['widget_name']);
 		$this->box_id = $array['widget_box'];
+		$this->set_warning(1);
 		foreach ($_SESSION['boxes'] as $box) {
 			if ($box['id'] == $this->box_id)
 				$this->widget_box = $box;

--- a/web/tools/system/monit/template/dashboard_widgets/monit_tools_widget.php
+++ b/web/tools/system/monit/template/dashboard_widgets/monit_tools_widget.php
@@ -9,6 +9,7 @@ class monit_tools_widget extends widget
     function __construct($array) {
         parent::__construct($array['panel_id'], $array['widget_name'], 2,2, $array['widget_name']);
 		$this->box_id = $array['widget_box'];
+		$this->set_warning(1);
 		$this->set_monitored();
     }
 


### PR DESCRIPTION
Remove warning bullet if widgets don't explicitly set it. Check if dashboard has at least one panel and if so, make that panel the homepage.