### PR TITLE
Fix chart and status report widgets, change variables names

### DIFF
--- a/web/common/charting/get_data.php
+++ b/web/common/charting/get_data.php
@@ -23,7 +23,7 @@
     $vals.="date,value";
     $chart_size = isset($_GET['chart_size'])?$_GET['chart_size']:$_SESSION['chart_size'];
     if ($zoomOut == 'true') {
-        $chart_size = $_SESSION['chart_history'];
+        $chart_size = isset($_GET['chart_size'])?$_GET['chart_size']:$_SESSION['chart_history'];
         if ($chart_size == "auto")
             $chart_size = 3 * 24; //3 days
     }

--- a/web/common/charting/get_multiple_data.php
+++ b/web/common/charting/get_multiple_data.php
@@ -25,7 +25,7 @@
     $vals.="date,value,name";
     $chart_size = isset($_GET['chart_size'])?$_GET['chart_size']:get_settings_value_from_tool("chart_size", "smonitor");
     if ($zoomOut == 'true') {
-    	$chart_size = get_settings_value_from_tool("chart_history", "smonitor");
+        $chart_size = isset($_GET['chart_size'])?$_GET['chart_size']:get_settings_value_from_tool("chart_history", "smonitor");
         if ($chart_size == "auto")
             $chart_size = 3 * 24; //3 days
     }

--- a/web/tools/system/dashboard/template/dashboard.main.php
+++ b/web/tools/system/dashboard/template/dashboard.main.php
@@ -121,7 +121,7 @@ if ($_SESSION['config']['panels'][$panel_id]['content'] != null) {
     $widget_positions = json_decode($widget['positions'], true);
     $new_widget = new $widget_content['widget_type']($widget_content);
     $new_widget->set_id($widget_content['widget_id']);
-    $widget_array = $new_widget->get_as_array();
+    $widget_array = $new_widget->get_as_array();//this returns info of widget as array
     $new_widget->display_widget();
 	/*
 	widget_positions is fetched from db. The following lines ignore the db widget sizes,
@@ -134,20 +134,20 @@ if ($_SESSION['config']['panels'][$panel_id]['content'] != null) {
 	
      ?>
 <script>
-    var widget_content = <?php echo json_encode($widget_array); ?>;
+    var widget_info = <?php echo json_encode($widget_array); ?>;
     var widget_type = <?php echo json_encode($widget_content['widget_type']);?>;
     var widget_positions = <?php echo json_encode($widget_positions); ?>;
     
     var col, row;
-    var sizeX = Number(widget_content[1]);
-    var sizeY = Number(widget_content[2]);
+    var sizeX = Number(widget_info[1]);
+    var sizeY = Number(widget_info[2]);
     if (widget_positions) {
         col = widget_positions.col;
         row = widget_positions.row;
         sizeX= widget_positions.size_x;
         sizeY = widget_positions.size_y;
     } 
-    addWidget(gridster,widget_content[0], sizeX, sizeY, col, row);
+    addWidget(gridster,widget_info[0], sizeX, sizeY, col, row);
     move(widget_positions.id.concat("_old"), widget_positions.id);
 </script>
      <?php 

--- a/web/tools/system/dashboard/template/dashboard_widgets/status_report_widget.php
+++ b/web/tools/system/dashboard/template/dashboard_widgets/status_report_widget.php
@@ -47,7 +47,7 @@ class status_report_widget extends widget
 		$params["group"] = $group;
 		if ($identifier)
 			$params["identifier"] = $identifier;
-		$stat_res = mi_command("sr_get_status", array("group" => $group), $this->widget_box['mi_conn'], $errors);
+        $stat_res = mi_command("sr_get_status", array("group" => $group), $this->widget_box['mi_conn'], $errors);
 		$this->status = $stat_res;
 	}
 
@@ -78,8 +78,14 @@ class status_report_widget extends widget
     }
 
     static function get_identifiers_options() {
+        function consoole_log( $data ){
+            echo '<script>';
+            echo 'console.log('. json_encode( $data ) .')';
+            echo '</script>';
+          } //  DE_STERS
         foreach($_SESSION['boxes'] as $id => $box) {
             $stat_res = mi_command("sr_list_identifiers", array(), $box['mi_conn'], $errors);
+            consoole_log($stat_res);
             foreach($stat_res as $group) {
                 foreach($group["Identifiers"] as $identifier)
                         $identifiers[$box['id']][] = $group["Group"]."/".$identifier;

--- a/web/tools/system/dashboard/template/dashboard_widgets/status_report_widget.php
+++ b/web/tools/system/dashboard/template/dashboard_widgets/status_report_widget.php
@@ -78,14 +78,8 @@ class status_report_widget extends widget
     }
 
     static function get_identifiers_options() {
-        function consoole_log( $data ){
-            echo '<script>';
-            echo 'console.log('. json_encode( $data ) .')';
-            echo '</script>';
-          } //  DE_STERS
         foreach($_SESSION['boxes'] as $id => $box) {
             $stat_res = mi_command("sr_list_identifiers", array(), $box['mi_conn'], $errors);
-            consoole_log($stat_res);
             foreach($stat_res as $group) {
                 foreach($group["Identifiers"] as $identifier)
                         $identifiers[$box['id']][] = $group["Group"]."/".$identifier;


### PR DESCRIPTION
Fix double click on chart widget, improper mi_command in status report widget, and change dashboard code variable