### PR TITLE
Update dispatcher.php

### DIFF
--- a/web/tools/system/dispatcher/dispatcher.php
+++ b/web/tools/system/dispatcher/dispatcher.php
@@ -266,6 +266,7 @@ if ($action=="change_state") {
 # start main #
 ##############
 
+$errors=[];
 require("template/".$page_id.".main.php");
 if ($errors!="") echo('<tr><td align="center"><div class="formError">'.$errors.'</div></td></tr>');
 if ($info!="") echo('<tr><td  align="center"><div class="formInfo">'.$info.'</div></td></tr>');


### PR DESCRIPTION
the require() on line 270 makes calls to mi_command() which passes the $errors variable by reference.

This then gets passed all over the place and is expected to be an array, not a string. 

Array initialisation on line 269 is required because $errors is defined as a string previously, this causes a type error when you try to load the dispatcher page:

PHP Fatal error:  Uncaught Error: [] operator not supported for strings