### PR TITLE
fix(tviewer): skip validation for fields hidden from add/edit forms

### DIFF
--- a/web/common/tools/tviewer/custom_actions/add.php
+++ b/web/common/tools/tviewer/custom_actions/add.php
@@ -32,6 +32,8 @@ if ($action=="add_verify")
 	$values="";
 
 	foreach ($custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['custom_table_column_defs'] as $key => $value) {
+		if (isset($value['show_in_add_form']) && $value['show_in_add_form'] == false)
+			continue;
 		$_SESSION[$key] = $_POST[$key];
 		if ($_POST[$key] == "" && isset($value["is_optional"]) && $value["is_optional"] == "y")
 			continue;

--- a/web/common/tools/tviewer/custom_actions/edit.php
+++ b/web/common/tools/tviewer/custom_actions/edit.php
@@ -33,7 +33,9 @@ if ($action=="modify")
 	if(!$_SESSION['read_only']){
 
 		foreach ($custom_config[$module_id][$_SESSION[$module_id]['submenu_item_id']]['custom_table_column_defs'] as $key => $value) {
-			$_SESSION[$key] = $_POST[$key];	
+			if (isset($value['show_in_edit_form']) && $value['show_in_edit_form'] == false)
+				continue;
+			$_SESSION[$key] = $_POST[$key];
 			if ($_POST[$key] == "" && isset($value["is_optional"]) && $value["is_optional"] == "y")
 				continue;
 			if (isset($value['validation_regex']) && !preg_match("/".$value['validation_regex']."/", $_POST[$key]))


### PR DESCRIPTION
Fields with show_in_add_form/show_in_edit_form set to false are not submitted via POST, so their validation_regex would always fail against an empty value.