### PR TITLE
ci: bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/docker-trigger.yml
+++ b/.github/workflows/docker-trigger.yml
@@ -16,7 +16,7 @@ jobs:
       run:  BRANCH="${GITHUB_REF#refs/heads/}"; echo -e "BRANCH=$BRANCH\nDOCKER_TAG=${BRANCH//master/latest}" >> $GITHUB_ENV
     
     - name: Repository Dispatch
-      uses: myrotvorets/trigger-repository-dispatch-action@1.1.0
+      uses: myrotvorets/trigger-repository-dispatch-action@v2.0.2
       with:
         token: ${{ secrets.DOCKER_OPENSIPS_CLI_PAT }}
         repo: OpenSIPS/docker-opensips-cp


### PR DESCRIPTION
Node 20 is being deprecated on GitHub Actions runners (EOL April 2026, [changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

Bumps `myrotvorets/trigger-repository-dispatch-action` from `1.1.0` (Node 12, already long past EOL) to `v2.0.2` (its latest release, Node 20). Upstream hasn't shipped a Node 24 build yet, so this doesn't fully close out the Node 20 deprecation for this one action, but it's a meaningful improvement over the current Node 12 pin. Inputs (`token`, `repo`, `type`, `payload`) are unchanged between the two versions.