### PR TITLE
ci: switch repository-dispatch trigger to actions/github-script

### DIFF
--- a/.github/workflows/docker-trigger.yml
+++ b/.github/workflows/docker-trigger.yml
@@ -16,9 +16,16 @@ jobs:
       run:  BRANCH="${GITHUB_REF#refs/heads/}"; echo -e "BRANCH=$BRANCH\nDOCKER_TAG=${BRANCH//master/latest}" >> $GITHUB_ENV
     
     - name: Repository Dispatch
-      uses: myrotvorets/trigger-repository-dispatch-action@1.1.0
+      uses: actions/github-script@v8
       with:
-        token: ${{ secrets.DOCKER_OPENSIPS_CLI_PAT }}
-        repo: OpenSIPS/docker-opensips-cp
-        type: OpenSIPS CP trigger
-        payload: '{"docker_tag": "${{ env.DOCKER_TAG }}", "branch": "${{ env.BRANCH}}"}'
+        github-token: ${{ secrets.DOCKER_OPENSIPS_CLI_PAT }}
+        script: |
+          await github.rest.repos.createDispatchEvent({
+            owner: 'OpenSIPS',
+            repo: 'docker-opensips-cp',
+            event_type: 'OpenSIPS CP trigger',
+            client_payload: {
+              docker_tag: process.env.DOCKER_TAG,
+              branch: process.env.BRANCH
+            }
+          });


### PR DESCRIPTION
Replaces #336/#337/#338/#339, which bumped `myrotvorets/trigger-repository-dispatch-action` from `1.1.0` to `v2.0.2` — that action's latest release still runs on Node 20 (EOL April 2026, [changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)) with no Node 24 build available upstream.

This instead switches the "Repository Dispatch" step to `actions/github-script@v8` (already Node 24), calling the same [`repos.createDispatchEvent`](https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event) REST endpoint directly. Same `event_type` (`OpenSIPS CP trigger`) and `client_payload` (`docker_tag`, `branch`) as before, so `docker-opensips-cp`'s `docker-image.yml` (which listens for this dispatch) needs no changes.

Note: this doesn't address the separate "Bad credentials" failure currently seen on this workflow's runs — that's a `DOCKER_OPENSIPS_CLI_PAT` secret issue, unrelated to the action itself.